### PR TITLE
Make door remotes also use ID card access, add Maintenance to fire-fighting door remote

### DIFF
--- a/Content.Server/Remotes/DoorRemoteSystem.cs
+++ b/Content.Server/Remotes/DoorRemoteSystem.cs
@@ -47,8 +47,10 @@ namespace Content.Shared.Remotes
                 return;
             }
 
+            // Holding the door remote grants you access to the relevant doors IN ADDITION to what ever access you had.
+            // This access is enforced in _doorSystem.HasAccess when it calls _accessReaderSystem.IsAllowed
             if (TryComp<AccessReaderComponent>(args.Target, out var accessComponent)
-                && !_doorSystem.HasAccess(args.Target.Value, args.Used, doorComp, accessComponent))
+                && !_doorSystem.HasAccess(args.Target.Value, args.User, doorComp, accessComponent))
             {
                 _doorSystem.Deny(args.Target.Value, doorComp, args.User);
                 Popup.PopupEntity(Loc.GetString("door-remote-denied"), args.User, args.User);
@@ -58,7 +60,10 @@ namespace Content.Shared.Remotes
             switch (entity.Comp.Mode)
             {
                 case OperatingMode.OpenClose:
-                    if (_doorSystem.TryToggleDoor(args.Target.Value, doorComp, args.Used))
+                    // Note we provide args.User here to TryToggleDoor as the "user"
+                    // This means that the door will look at all access items carryed by the player for access, including
+                    // this remote, but also including anything else they are carrying such as a PDA or ID card.
+                    if (_doorSystem.TryToggleDoor(args.Target.Value, doorComp, args.User))
                         _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)}: {doorComp.State}");
                     break;
                 case OperatingMode.ToggleBolts:
@@ -66,7 +71,7 @@ namespace Content.Shared.Remotes
                     {
                         if (!boltsComp.BoltWireCut)
                         {
-                            _doorSystem.SetBoltsDown((args.Target.Value, boltsComp), !boltsComp.BoltsDown, args.Used);
+                            _doorSystem.SetBoltsDown((args.Target.Value, boltsComp), !boltsComp.BoltsDown, args.User);
                             _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to {(boltsComp.BoltsDown ? "" : "un")}bolt it");
                         }
                     }

--- a/Resources/Prototypes/Access/engineering.yml
+++ b/Resources/Prototypes/Access/engineering.yml
@@ -22,3 +22,4 @@
   tags:
     - Engineering
     - Atmospherics
+    - Maintenance


### PR DESCRIPTION
Door remotes now use the person's access level in addition to the remote. This was the upstream behavior up until recently when they made it that remotes only use their own access.

In addition, added Maintenance access to the fire-fighting door remote, since it was missing.

Fixes #19 

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.

-->

:cl:
- tweak: Door remotes now use your personal access in addition to the remote's own access
- fix: Added missing Maintenance access to Atmos' fire-fighting door remote
