### PR TITLE
Feature/balanced pipe stacking

### DIFF
--- a/Content.Server/Atmos/EntitySystems/PipeRestrictOverlapSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/PipeRestrictOverlapSystem.cs
@@ -25,6 +25,9 @@ public sealed class PipeRestrictOverlapSystem : EntitySystem
 
     private readonly List<EntityUid> _anchoredEntities = new();
     private EntityQuery<NodeContainerComponent> _nodeContainerQuery;
+    // Goobstation - Allow device-on-pipe stacking
+    private EntityQuery<PipeRestrictOverlapComponent> _restrictOverlapQuery;
+
     public bool StrictPipeStacking = false;
 
     /// <inheritdoc/>
@@ -35,6 +38,8 @@ public sealed class PipeRestrictOverlapSystem : EntitySystem
         Subs.CVar(_cfg, CCVars.StrictPipeStacking, (bool val) => {StrictPipeStacking = val;}, false);
 
         _nodeContainerQuery = GetEntityQuery<NodeContainerComponent>();
+        // Goobstation - Allow device-on-pipe stacking
+        _restrictOverlapQuery = GetEntityQuery<PipeRestrictOverlapComponent>();
     }
 
     private void OnAnchorStateChanged(Entity<PipeRestrictOverlapComponent> ent, ref AnchorStateChangedEvent args)
@@ -93,6 +98,10 @@ public sealed class PipeRestrictOverlapSystem : EntitySystem
                 continue;
 
             if (!_nodeContainerQuery.TryComp(otherEnt, out var otherComp))
+                continue;
+
+            // Goobstation - Allow device-on-pipe stacking
+            if (!_restrictOverlapQuery.HasComp(otherEnt))
                 continue;
 
             var (overlapping, which) = PipeNodesOverlap(ent, (otherEnt, otherComp, Transform(otherEnt)), takenDirs);

--- a/Content.Server/Atmos/EntitySystems/PipeRestrictOverlapSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/PipeRestrictOverlapSystem.cs
@@ -4,9 +4,11 @@ using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.Nodes;
 using Content.Server.Popups;
 using Content.Shared.Atmos;
+using Content.Shared.CCVar;
 using Content.Shared.Construction.Components;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
+using Robust.Shared.Configuration;
 using Robust.Shared.Map.Components;
 
 namespace Content.Server.Atmos.EntitySystems;
@@ -16,18 +18,21 @@ namespace Content.Server.Atmos.EntitySystems;
 /// </summary>
 public sealed class PipeRestrictOverlapSystem : EntitySystem
 {
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly TransformSystem _xform = default!;
 
     private readonly List<EntityUid> _anchoredEntities = new();
     private EntityQuery<NodeContainerComponent> _nodeContainerQuery;
+    public bool StrictPipeStacking = false;
 
     /// <inheritdoc/>
     public override void Initialize()
     {
         SubscribeLocalEvent<PipeRestrictOverlapComponent, AnchorStateChangedEvent>(OnAnchorStateChanged);
         SubscribeLocalEvent<PipeRestrictOverlapComponent, AnchorAttemptEvent>(OnAnchorAttempt);
+        Subs.CVar(_cfg, CCVars.StrictPipeStacking, (bool val) => {StrictPipeStacking = val;}, false);
 
         _nodeContainerQuery = GetEntityQuery<NodeContainerComponent>();
     }
@@ -78,6 +83,9 @@ public sealed class PipeRestrictOverlapSystem : EntitySystem
         _anchoredEntities.Clear();
         _map.GetAnchoredEntities((grid, gridComp), indices, _anchoredEntities);
 
+        // ATMOS: change to long if you add more pipe layers than 5 + z levels
+        var takenDirs = PipeDirection.None;
+
         foreach (var otherEnt in _anchoredEntities)
         {
             // this should never actually happen but just for safety
@@ -87,28 +95,40 @@ public sealed class PipeRestrictOverlapSystem : EntitySystem
             if (!_nodeContainerQuery.TryComp(otherEnt, out var otherComp))
                 continue;
 
-            if (PipeNodesOverlap(ent, (otherEnt, otherComp, Transform(otherEnt))))
+            var (overlapping, which) = PipeNodesOverlap(ent, (otherEnt, otherComp, Transform(otherEnt)), takenDirs);
+            takenDirs |= which;
+
+            if (overlapping)
                 return true;
         }
 
         return false;
     }
 
-    public bool PipeNodesOverlap(Entity<NodeContainerComponent, TransformComponent> ent, Entity<NodeContainerComponent, TransformComponent> other)
+    public (bool, PipeDirection) PipeNodesOverlap(Entity<NodeContainerComponent, TransformComponent> ent, Entity<NodeContainerComponent, TransformComponent> other, PipeDirection takenDirs)
     {
         var entDirs = GetAllDirections(ent).ToList();
         var otherDirs = GetAllDirections(other).ToList();
+        var entDirsCollapsed = PipeDirection.None;
 
         foreach (var dir in entDirs)
         {
+            entDirsCollapsed |= dir;
             foreach (var otherDir in otherDirs)
             {
-                if ((dir & otherDir) != 0)
-                    return true;
+                takenDirs |= otherDir;
+                if (StrictPipeStacking)
+                    if ((dir & otherDir) != 0)
+                        return (true, takenDirs);
+                else
+                    if ((dir ^ otherDir) != 0)
+                        break;
             }
         }
 
-        return false;
+        // If no strict pipe stacking, then output ("are all entDirs occupied", takenDirs)
+
+        return (StrictPipeStacking ? false : ((takenDirs & entDirsCollapsed) == entDirsCollapsed), takenDirs);
 
         IEnumerable<PipeDirection> GetAllDirections(Entity<NodeContainerComponent, TransformComponent> pipe)
         {

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1000,6 +1000,13 @@ namespace Content.Shared.CCVar
             CVarDef.Create("atmos.space_wind", true, CVar.SERVERONLY);
 
         /// <summary>
+        ///     Whether pipes will unanchor on ANY conflicting connection. May break maps.
+        ///     If false, allows you to stack pipes as long as new directions are added (i.e. in a new pipe rotation, layer or multi-Z link), otherwise unanchoring them.
+        /// </summary>
+        public static readonly CVarDef<bool> StrictPipeStacking =
+            CVarDef.Create("atmos.strict_pipe_stacking", false, CVar.SERVERONLY);
+
+        /// <summary>
         ///     Divisor from maxForce (pressureDifference * 2.25f) to force applied on objects.
         /// </summary>
         public static readonly CVarDef<float> SpaceWindPressureForceDivisorThrow =

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -358,7 +358,8 @@
   - type: PipeColorVisuals
   - type: Rotatable
   - type: GasRecycler
-  - type: PipeRestrictOverlap
+  # Goobstation - Allow device-on-pipe stacking
+  # - type: PipeRestrictOverlap
   - type: NodeContainer
     nodes:
       inlet:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -51,7 +51,8 @@
   - type: Appearance
   - type: PipeColorVisuals
   - type: NodeContainer
-  - type: PipeRestrictOverlap
+  # Goobstation - Allow device-on-pipe stacking
+  # - type: PipeRestrictOverlap
   - type: AtmosUnsafeUnanchor
   - type: AtmosPipeColor
   - type: Tag
@@ -63,10 +64,19 @@
   - type: StaticPrice
     price: 11
 
+# Goobstation - Allow device-on-pipe stacking
+- type: entity
+  abstract: true
+  parent: GasPipeBase
+  id: GasPipeNoOverlap
+  components:
+  - type: PipeRestrictOverlap
+
 #Note: The PipeDirection of the PipeNode should be the south-facing version, because the entity starts at an angle of 0 (south)
 
 - type: entity
-  parent: GasPipeBase
+  # Goobstation - Allow device-on-pipe stacking
+  parent: GasPipeNoOverlap
   id: GasPipeHalf
   suffix: Half
   components:
@@ -85,7 +95,8 @@
     node: half
 
 - type: entity
-  parent: GasPipeBase
+  # Goobstation - Allow device-on-pipe stacking
+  parent: GasPipeNoOverlap
   id: GasPipeStraight
   suffix: Straight
   components:
@@ -118,7 +129,8 @@
       collection: MetalThud # this NEEDS to changed to the metal pipe falling sound effect on april first every year
 
 - type: entity
-  parent: GasPipeBase
+  # Goobstation - Allow device-on-pipe stacking
+  parent: GasPipeNoOverlap
   id: GasPipeBend
   suffix: Bend
   components:
@@ -158,7 +170,8 @@
         Blunt: 3 #This should be 6 but throwing damage is doubled at the moment for some reason so for now it's 3
 
 - type: entity
-  parent: GasPipeBase
+  # Goobstation - Allow device-on-pipe stacking
+  parent: GasPipeNoOverlap
   id: GasPipeTJunction
   suffix: TJunction
   components:
@@ -194,7 +207,8 @@
       collection: MetalThud
 
 - type: entity
-  parent: GasPipeBase
+  # Goobstation - Allow device-on-pipe stacking
+  parent: GasPipeNoOverlap
   id: GasPipeFourway
   suffix: Fourway
   components:
@@ -230,7 +244,8 @@
 
 - type: entity
   id: GasPipeBroken
-  parent: GasPipeBase
+  # Goobstation - Allow device-on-pipe stacking
+  parent: GasPipeNoOverlap
   name: broken pipe
   description: It used to hold gas.
   components:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -249,7 +249,8 @@
       key: enum.ThermomachineUiKey.Key
     - type: WiresPanel
     - type: WiresVisuals
-    - type: PipeRestrictOverlap
+  # Goobstation - Allow device-on-pipe stacking
+  # - type: PipeRestrictOverlap
     - type: NodeContainer
       nodes:
         pipe:
@@ -424,7 +425,8 @@
   - type: GasCondenser
   - type: AtmosPipeColor
   - type: AtmosDevice
-  - type: PipeRestrictOverlap
+  # Goobstation - Allow device-on-pipe stacking
+  # - type: PipeRestrictOverlap
   - type: ApcPowerReceiver
     powerLoad: 10000
   - type: Machine

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
@@ -176,7 +176,8 @@
           nodeGroupID: Teg
 
     - type: AtmosUnsafeUnanchor
-    - type: PipeRestrictOverlap
+    # Goobstation - Allow device-on-pipe stacking
+    # - type: PipeRestrictOverlap
     - type: TegCirculator
     - type: StealTarget
       stealGroup: Teg


### PR DESCRIPTION
Fixes #8 

Pipe stacking permitted if it adds a new direction. Stacking devices on top of pipes is also permitted.

**Changelog**

:cl:
- tweak: Pipe stacking is permitted if it adds a new direction
- tweak: Anchoring devices on top of pipes is permitted again

