### PR TITLE
Make the vast majority of ghost roles require server whitelisting

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -3,8 +3,7 @@
 lobbyenabled = false
 # Dev map for faster loading & convenience
 map = "Dev"
-role_timers = true
-role_whitelist = true
+role_timers = false
 
 [gateway]
 generator_enabled = false

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -3,7 +3,8 @@
 lobbyenabled = false
 # Dev map for faster loading & convenience
 map = "Dev"
-role_timers = false
+role_timers = true
+role_whitelist = true
 
 [gateway]
 generator_enabled = false

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/ghost_roles.yml
@@ -41,6 +41,7 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 40000 # 11.1 hours
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
 
 - type: entity
   noSpawn: true
@@ -52,6 +53,8 @@
     name: ghost-role-information-paradox-anomaly-name
     description: ghost-role-information-paradox-anomaly-description
     rules: ghost-role-information-paradox-anomaly-rules
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
 
 - type: entity
   noSpawn: true
@@ -83,6 +86,7 @@
     - !type:RoleTimeRequirement
       role: JobLawyer
       time: 3600 # 1h as lawyer so you maybe know how to paperwork
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: Sprite
     layers:
     - state: green

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/animals.yml
@@ -79,6 +79,8 @@
     allowMovement: true
     name: "sentient security dog"
     description: "Help out the security team by biting the baddies and barking at everything that moves."
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Security roles
   - type: GhostTakeoverAvailable
   - type: CombatMode
   - type: MovementSpeedModifier

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/familiars.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/familiars.yml
@@ -106,6 +106,7 @@
     - !type:DepartmentTimeRequirement
       department: Epistemics
       time: 14400 # DeltaV - 4 hours
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
 
 - type: entity
   parent: WelderExperimental

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/nukiemouse.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/nukiemouse.yml
@@ -11,6 +11,8 @@
     allowMovement: true
     name: ghost-role-information-nukie-mouse-name
     description: ghost-role-information-nukie-mouse-description
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostTakeoverAvailable
   - type: RandomMetadata
     nameSegments: [names_mouse_death_commando]

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/pets.yml
@@ -76,4 +76,5 @@
     - !type:DepartmentTimeRequirement
       department: Justice
       time: 3600 # 1 hours
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
   - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/pets.yml
@@ -35,6 +35,7 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 14400 # DeltaV - 4 hours
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Security roles
   - type: GhostTakeoverAvailable
   - type: InteractionPopup
     successChance: 1

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Player/humanoid.yml
@@ -22,6 +22,8 @@
     - type: GhostRole
       name: Mobster
       description: Break kneecaps, spray lead, keep your mouth shut.
+      requirements:
+      - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ MobsterGear ]

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -12,6 +12,8 @@
     name: ghost-role-information-nukie-mouse-name
     description: ghost-role-information-nukie-mouse-description
     rules: ghost-role-information-nukie-mouse-rules
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostRoleMobSpawner
     prototype: MobNukieMouse
   - type: EmitSoundOnUse

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -21,6 +21,8 @@
     rules: ghost-role-information-rat-king-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostRoleMobSpawner
     prototype: MobRatKing
   - type: Sprite
@@ -63,6 +65,8 @@
     rules: ghost-role-information-cerberus-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostRoleMobSpawner
     prototype: MobCorgiCerberus
   - type: Sprite
@@ -83,6 +87,8 @@
     rules: ghost-role-information-nukeop-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostRoleMobSpawner
     prototype: MobHumanNukeOp
   - type: Sprite
@@ -107,6 +113,7 @@
     - !type:DepartmentTimeRequirement # DeltaV - Security dept time requirement
       department: Security
       time: 36000 # DeltaV - 10 hours
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostRoleAntagSpawner
   - type: Sprite
     sprite: Markers/jobs.rsi
@@ -123,6 +130,8 @@
   - type: GhostRole
     name: roles-antag-nuclear-operative-commander-name
     description: roles-antag-nuclear-operative-commander-objective
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
 
 - type: entity
   noSpawn: true
@@ -132,6 +141,8 @@
   - type: GhostRole
     name: roles-antag-nuclear-operative-agent-name
     description: roles-antag-nuclear-operative-agent-objective
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
 
 - type: entity
   noSpawn: true

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1122,6 +1122,8 @@
     prob: 0.25
     name: ghost-role-information-kangaroo-name
     description: ghost-role-information-kangaroo-description
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
   - type: GhostTakeoverAvailable
   - type: Vocal
     sounds:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1333,6 +1333,8 @@
     description: ghost-role-information-monkey-description
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
   - type: GhostTakeoverAvailable
   - type: Loadout
     prototypes: [SyndicateOperativeGearMonkey]
@@ -1494,6 +1496,9 @@
     - Syndicate
   - type: Loadout
     prototypes: [SyndicateOperativeGearMonkey]
+  - type: GhostRole
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
 
 - type: entity
   id: MobKoboldSyndicateAgent
@@ -1834,7 +1839,7 @@
       state: slug
       sprite: Mobs/Animals/slug.rsi
   - type: Carriable #DeltaV
-    freeHandsRequired: 1 
+    freeHandsRequired: 1
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2303,6 +2308,8 @@
       rules: deltav-ghost-role-information-softantag-rules #DeltaV
       raffle:
         settings: short
+      requirements:
+      - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
     - type: GhostTakeoverAvailable
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -234,6 +234,8 @@
     description: ghost-role-information-angry-slimes-description
     raffle:
       settings: short
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
   - type: NpcFactionMember
     factions:
     - SimpleHostile

--- a/Resources/Prototypes/Entities/Mobs/NPCs/hellspawn.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/hellspawn.yml
@@ -14,6 +14,8 @@
     description: ghost-role-information-hellspawn-description
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
   - type: RotationVisuals
     defaultRotation: 90
     horizontalRotation: 90

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -611,6 +611,7 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 14400 # DeltaV - 4 hours
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
   - type: GhostTakeoverAvailable # DeltaV
   - type: InteractionPopup
     successChance: 0.5 # spider is mean

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -92,6 +92,8 @@
     rules: ghost-role-information-rat-king-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
   - type: GhostTakeoverAvailable
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -62,6 +62,8 @@
     rules: ghost-role-information-revenant-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all  roles
   - type: GhostTakeoverAvailable
   - type: Revenant
     spawnOnDeathPrototype: EctoplasmRevenant #DeltaV - different prototype that contains more ectoplasm reagent for normality crystals

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -11,7 +11,7 @@
     layers:
     - map: [ "enum.DamageStateVisualLayers.Base" ]
       state: blue_adult_slime
-  - type: Carriable #DeltaV 
+  - type: Carriable #DeltaV
   - type: Fixtures
     fixtures:
       fix1:
@@ -131,6 +131,8 @@
     rules: deltav-ghost-role-information-softantag-rules #DeltaV
     raffle:
       settings: short
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
   - type: Speech
     speechVerb: Slime
     speechSounds: Slime

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -52,6 +52,8 @@
     rules: ghost-role-information-cerberus-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostTakeoverAvailable
   - type: MeleeWeapon
     altDisarm: false

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -124,6 +124,8 @@
       description: ghost-role-information-holoparasite-description
       raffle:
         settings: default
+      requirements:
+      - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
     - type: GhostTakeoverAvailable
     - type: NameIdentifier
       group: Holoparasite
@@ -156,6 +158,8 @@
       description: ghost-role-information-ifrit-description
       raffle:
         settings: default
+      requirements:
+      - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
     - type: GhostTakeoverAvailable
     - type: RandomSprite
       available:
@@ -184,6 +188,8 @@
       description: ghost-role-information-holoclown-description
       raffle:
         settings: default
+      requirements:
+      - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
     - type: GhostTakeoverAvailable
     - type: NameIdentifier
       group: Holoparasite

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -42,6 +42,8 @@
       description: ghost-role-information-Death-Squad-description
       raffle:
         settings: short
+      requirements:
+      - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
     - type: Loadout
       prototypes: [ DeathSquadGear ]
     - type: RandomMetadata
@@ -78,6 +80,8 @@
       description: ghost-role-information-ert-leader-description
       raffle:
         settings: short
+      requirements:
+      - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
     - type: Loadout
       prototypes: [ ERTLeaderGear ]
     - type: RandomMetadata
@@ -380,6 +384,8 @@
       description: ghost-role-information-ert-security-description
       raffle:
         settings: short
+      requirements:
+      - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
     - type: Loadout
       prototypes: [ ERTSecurityGearEVALecter ]
 

--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -8,7 +8,7 @@
     interactSuccessString: hugging-success-generic
     interactSuccessSound: /Audio/Effects/thudswoosh.ogg
     messagePerceivedByOthers: hugging-success-generic-others
-  - type: PotentialPsionic #Nyano - Summary: makes potentially psionic. 
+  - type: PotentialPsionic #Nyano - Summary: makes potentially psionic.
 
 - type: entity
   name: skeleton pirate
@@ -20,6 +20,8 @@
     description: ghost-role-information-skeleton-pirate-description
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostTakeoverAvailable
   - type: Loadout
     prototypes: [PirateGear]
@@ -36,6 +38,8 @@
     description: ghost-role-information-skeleton-biker-description
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostTakeoverAvailable
   - type: Loadout
     prototypes: [SkeletonBiker]
@@ -53,6 +57,7 @@
     requirements:
     - !type:OverallPlaytimeRequirement
       time: 172800 # DeltaV - 48 hours
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
     raffle:
       settings: default
   - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -14,6 +14,8 @@
     rules: ghost-role-information-syndicate-reinforcement-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostRoleMobSpawner
     prototype: MobHumanSyndicateAgent
   - type: EmitSoundOnUse
@@ -41,6 +43,8 @@
     rules: ghost-role-information-syndicate-monkey-reinforcement-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostRoleMobSpawner
     prototype: MobMonkeySyndicateAgent
     selectablePrototypes: ["SyndicateMonkey", "SyndicateKobold"]
@@ -66,6 +70,8 @@
     rules: ghost-role-information-SyndiCat-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostRoleMobSpawner
     prototype: MobCatSyndy
   - type: EmitSoundOnUse
@@ -84,5 +90,7 @@
       rules: Normal syndicate antagonist rules apply. Work with whoever called you in, and don't harm them.
       raffle:
         settings: default
+      requirements:
+      - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
     - type: GhostRoleMobSpawner
       prototype: PlayerBorgSyndicateAssaultBattery

--- a/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/ghost_roles.yml
@@ -11,6 +11,8 @@
     name: Mystagogue's Ifrit
     description: Obey the mystagogue. Defend the oracle.
     rules: You are a servant of the mystagogue. Obey them directly.
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
@@ -13,6 +13,8 @@
     name: salvage snake
     description: You are a salvage snake hunting for a meal.
     rules: deltav-ghost-role-information-salvageantag-rules # DeltaV salvage mob rules
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: SalvageMobRestrictions
 
 - type: entity
@@ -27,6 +29,8 @@
     name: salvage snake
     description: You are a salvage snake hunting for a meal.
     rules: deltav-ghost-role-information-salvageantag-rules # DeltaV salvage mob rules
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: SalvageMobRestrictions
 
 # Delta V variants of Xenos to allow ghost takeover again
@@ -46,6 +50,8 @@
     rules: ghost-role-information-xeno-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -63,6 +69,8 @@
     rules: ghost-role-information-xeno-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -80,6 +88,8 @@
     rules: ghost-role-information-xeno-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -97,6 +107,8 @@
     rules: ghost-role-information-xeno-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -114,6 +126,8 @@
     rules: ghost-role-information-xeno-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -131,6 +145,8 @@
     rules: ghost-role-information-xeno-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -147,6 +163,8 @@
     rules: ghost-role-information-xeno-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -164,4 +182,6 @@
     rules: ghost-role-information-xeno-rules
     raffle:
       settings: default
+    requirements:
+    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/Roles/Ghostroles/syndicate.yml
+++ b/Resources/Prototypes/Roles/Ghostroles/syndicate.yml
@@ -4,8 +4,6 @@
   description: ghost-role-information-syndicate-kobold-reinforcement-description
   rules: ghost-role-information-syndicate-kobold-reinforcement-rules
   entityPrototype: MobKoboldSyndicateAgent
-  requirements:
-  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
 
 - type: ghostRole
   id: SyndicateKoboldNukeops
@@ -13,8 +11,6 @@
   description: ghost-role-information-syndicate-kobold-reinforcement-description
   rules: ghost-role-information-syndicate-kobold-reinforcement-rules
   entityPrototype: MobKoboldSyndicateAgentNukeops
-  requirements:
-  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
 
 - type: ghostRole
   id: SyndicateMonkey
@@ -22,8 +18,6 @@
   description: ghost-role-information-syndicate-monkey-reinforcement-description
   rules: ghost-role-information-syndicate-monkey-reinforcement-name
   entityPrototype: MobMonkeySyndicateAgent
-  requirements:
-  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
 
 - type: ghostRole
   id: SyndicateMonkeyNukeops
@@ -31,5 +25,3 @@
   description: ghost-role-information-syndicate-monkey-reinforcement-description
   rules: ghost-role-information-syndicate-monkey-reinforcement-name
   entityPrototype: MobMonkeySyndicateAgentNukeops
-  requirements:
-  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles


### PR DESCRIPTION
- Fix broken YML
- Make riskier ghost roles actually require whitelisting

:cl:
- tweak: Made most antag/riskier ghost roles require server whitelisting
