### PR TITLE
Add global role-time requirement multiplier to allow for slow ramp up

### DIFF
--- a/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
+++ b/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
@@ -120,12 +120,12 @@ public sealed partial class JobRequirementsManager : ISharedPlaytimeManager
         if (requirements == null)
             return true;
 
-        var roleTimersEnabled = _cfg.GetCVar(CCVars.GameRoleTimers);
+        var roleTimersMultiplier = _cfg.GetCVar(CCVars.GameRoleTimers) ? _cfg.GetCVar(CCVars.GameRoleTimersMultiplier) : 0f;
 
         var reasons = new List<string>();
         foreach (var requirement in requirements)
         {
-            if (JobRequirements.TryRequirementMet(requirement, _roles, out var jobReason, _entManager, _prototypes, roleTimersEnabled, _whitelisted))
+            if (JobRequirements.TryRequirementMet(requirement, _roles, out var jobReason, _entManager, _prototypes, roleTimersMultiplier, _whitelisted))
                 continue;
 
             reasons.Add(jobReason.ToMarkup());

--- a/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
+++ b/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
@@ -209,7 +209,13 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
 
         var isWhitelisted = player.ContentData()?.Whitelisted ?? false; // DeltaV - Whitelist requirement
 
-        return JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes, _cfg.GetCVar(CCVars.GameRoleTimers), isWhitelisted);
+        return JobRequirements.TryRequirementsMet(job,
+            playTimes,
+            out _,
+            EntityManager,
+            _prototypes,
+            _cfg.GetCVar(CCVars.GameRoleTimers) ? _cfg.GetCVar(CCVars.GameRoleTimersMultiplier) : 0f,
+            isWhitelisted);
     }
 
     public HashSet<ProtoId<JobPrototype>> GetDisallowedJobs(ICommonSession player)
@@ -223,11 +229,17 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
         }
 
         var isWhitelisted = player.ContentData()?.Whitelisted ?? false; // DeltaV - Whitelist requirement
-        var roleTimersEnabled = _cfg.GetCVar(CCVars.GameRoleTimers);
+        var roleTimersMultiplier = _cfg.GetCVar(CCVars.GameRoleTimers) ? _cfg.GetCVar(CCVars.GameRoleTimersMultiplier) : 0f;
 
         foreach (var job in _prototypes.EnumeratePrototypes<JobPrototype>())
         {
-            if (JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes, roleTimersEnabled, isWhitelisted))
+            if (JobRequirements.TryRequirementsMet(job,
+                    playTimes,
+                    out _,
+                    EntityManager,
+                    _prototypes,
+                    roleTimersMultiplier,
+                    isWhitelisted))
                 roles.Add(job.ID);
         }
 
@@ -248,12 +260,18 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
         }
 
         var isWhitelisted = player.ContentData()?.Whitelisted ?? false; // DeltaV - Whitelist requirement
-        var roleTimersEnabled = _cfg.GetCVar(CCVars.GameRoleTimers);
+        var roleTimersMultiplier = _cfg.GetCVar(CCVars.GameRoleTimers) ? _cfg.GetCVar(CCVars.GameRoleTimersMultiplier) : 0f;
 
         for (var i = 0; i < jobs.Count; i++)
         {
             if (_prototypes.TryIndex(jobs[i], out var job)
-                && JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes, roleTimersEnabled, isWhitelisted))
+                && JobRequirements.TryRequirementsMet(job,
+                    playTimes,
+                    out _,
+                    EntityManager,
+                    _prototypes,
+                    roleTimersMultiplier,
+                    isWhitelisted))
             {
                 continue;
             }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -221,6 +221,12 @@ namespace Content.Shared.CCVar
             GameRoleTimers = CVarDef.Create("game.role_timers", true, CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
+        /// Multiplier to apply to role time requirements. Only applicable when game.role_timers is also set.
+        /// </summary>
+        public static readonly CVarDef<float>
+            GameRoleTimersMultiplier = CVarDef.Create("game.role_timers_multiplier", 1.0f, CVar.SERVER | CVar.REPLICATED);
+
+        /// <summary>
         /// Override default role requirements using a <see cref="JobRequirementOverridePrototype"/>
         /// </summary>
         public static readonly CVarDef<string>

--- a/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
@@ -24,11 +24,14 @@ public sealed partial class JobRequirementLoadoutEffect : LoadoutEffect
         var playtimes = manager.GetPlayTimes(session);
         var isWhitelisted = session.ContentData()?.Whitelisted ?? false; // DeltaV - Whitelist requirement
         var roleTimersEnabled = collection.Resolve<IConfigurationManager>().GetCVar(CCVars.GameRoleTimers);
+        var roleTimersMultiplier = roleTimersEnabled
+            ? collection.Resolve<IConfigurationManager>().GetCVar(CCVars.GameRoleTimersMultiplier)
+            : 0f;
 
         return JobRequirements.TryRequirementMet(Requirement, playtimes, out reason,
             collection.Resolve<IEntityManager>(),
             collection.Resolve<IPrototypeManager>(),
-            roleTimersEnabled,
+            roleTimersMultiplier,
             isWhitelisted); // DeltaV
     }
 }

--- a/Content.Shared/Roles/JobRequirements.cs
+++ b/Content.Shared/Roles/JobRequirements.cs
@@ -168,7 +168,9 @@ namespace Content.Shared.Roles
                         return true;
 
                     var overallTime = playTimes.GetValueOrDefault(PlayTimeTrackingShared.TrackerOverall);
-                    var overallDiff = overallRequirement.Time.TotalMinutes - overallTime.TotalMinutes;
+                    // Apply multiplier to overall time requirements, but with a minimum for 2 hrs.
+                    // Reason being we rely on this specifically to protect against raiders.
+                    var overallDiff = Math.Min(7200, overallRequirement.Time.TotalMinutes * roleTimersMultiplier) - overallTime.TotalMinutes;
 
                     if (!overallRequirement.Inverted)
                     {

--- a/Content.Shared/Roles/JobRequirements.cs
+++ b/Content.Shared/Roles/JobRequirements.cs
@@ -170,7 +170,7 @@ namespace Content.Shared.Roles
                     var overallTime = playTimes.GetValueOrDefault(PlayTimeTrackingShared.TrackerOverall);
                     // Apply multiplier to overall time requirements, but with a minimum for 2 hrs.
                     // Reason being we rely on this specifically to protect against raiders.
-                    var overallDiff = Math.Min(7200, overallRequirement.Time.TotalMinutes * roleTimersMultiplier) - overallTime.TotalMinutes;
+                    var overallDiff = Math.Max(7200, overallRequirement.Time.TotalMinutes * roleTimersMultiplier) - overallTime.TotalMinutes;
 
                     if (!overallRequirement.Inverted)
                     {

--- a/Content.Shared/Roles/JobRequirements.cs
+++ b/Content.Shared/Roles/JobRequirements.cs
@@ -168,9 +168,9 @@ namespace Content.Shared.Roles
                         return true;
 
                     var overallTime = playTimes.GetValueOrDefault(PlayTimeTrackingShared.TrackerOverall);
-                    // Apply multiplier to overall time requirements, but with a minimum for 2 hrs.
+                    // Apply multiplier to overall time requirements, but with a minimum for 1 hr.
                     // Reason being we rely on this specifically to protect against raiders.
-                    var overallDiff = Math.Max(120, overallRequirement.Time.TotalMinutes * roleTimersMultiplier) - overallTime.TotalMinutes;
+                    var overallDiff = Math.Max(60, overallRequirement.Time.TotalMinutes * roleTimersMultiplier) - overallTime.TotalMinutes;
 
                     if (!overallRequirement.Inverted)
                     {

--- a/Content.Shared/Roles/JobRequirements.cs
+++ b/Content.Shared/Roles/JobRequirements.cs
@@ -170,7 +170,7 @@ namespace Content.Shared.Roles
                     var overallTime = playTimes.GetValueOrDefault(PlayTimeTrackingShared.TrackerOverall);
                     // Apply multiplier to overall time requirements, but with a minimum for 2 hrs.
                     // Reason being we rely on this specifically to protect against raiders.
-                    var overallDiff = Math.Max(7200, overallRequirement.Time.TotalMinutes * roleTimersMultiplier) - overallTime.TotalMinutes;
+                    var overallDiff = Math.Max(120, overallRequirement.Time.TotalMinutes * roleTimersMultiplier) - overallTime.TotalMinutes;
 
                     if (!overallRequirement.Inverted)
                     {

--- a/Resources/ConfigPresets/EchoStation/alpha.toml
+++ b/Resources/ConfigPresets/EchoStation/alpha.toml
@@ -1,8 +1,9 @@
 ﻿[game]
 hostname = "[EN][MRP/HRP] 🔷 Echo Station: Alpha | Public tryout slots! [US East]"
 
-# For the time being, disable role timers:
-role_timers = false
+# Role timers are now ON, but all time requirements are multiplied by the multiplier below.
+role_timers = true
+role_timers_multiplier = 0.2 # Increment this over time as people get more playtime in
 role_whitelist = true
 
 [hub]
@@ -10,7 +11,6 @@ role_whitelist = true
 advertise = false
 # English, America > North America > East, High RP, don't guess tags based on server name.
 tags = "lang:en-US,region:am_n_e,rp:med,no_tag_infer"
-
 
 # Individual instance configs should set the following settings:
 #

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Cargo/courier.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Cargo/courier.yml
@@ -5,9 +5,8 @@
   startingGear: CourierGear
   playTimeTracker: JobCourier
   requirements:
-    # Echo Station: Remove most time requirements
-#  - !type:OverallPlaytimeRequirement
-#    time: 3600 # 1 hr
+  - !type:OverallPlaytimeRequirement
+    time: 3600 # 1 hr
   icon: "JobIconCourier"
   supervisors: job-supervisors-qm
   access:

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
@@ -4,17 +4,15 @@
   description: job-description-chief-justice
   playTimeTracker: JobChiefJustice
   requirements:
-  #    - !type:RoleTimeRequirement # DeltaV - Comment out clerk time till more people have clerk time. Maybe a week or so.
-  #      role: JobClerk
-  #      time: 36000 # DeltaV - 10 hours
+  - !type:RoleTimeRequirement
+    role: JobClerk
+    time: 36000 # DeltaV - 10 hours
   - !type:RoleTimeRequirement
     role: JobLawyer
     time: 36000 # 10 hours
   - !type:RoleTimeRequirement
     role: JobProsecutor
     time: 36000 # 10 hours
-  - !type:OverallPlaytimeRequirement
-    time: 90000 # 25 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 20
   startingGear: CJGear

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
@@ -4,19 +4,18 @@
   description: job-description-chief-justice
   playTimeTracker: JobChiefJustice
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:RoleTimeRequirement # DeltaV - Comment out clerk time till more people have clerk time. Maybe a week or so.
-#      role: JobClerk
-#      time: 36000 # DeltaV - 10 hours
-#    - !type:RoleTimeRequirement
-#      role: JobLawyer
-#      time: 36000 # 10 hours
-#    - !type:RoleTimeRequirement
-#      role: JobProsecutor
-#      time: 36000 # 10 hours
-#    - !type:OverallPlaytimeRequirement
-#      time: 90000 # 25 hours
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
+  #    - !type:RoleTimeRequirement # DeltaV - Comment out clerk time till more people have clerk time. Maybe a week or so.
+  #      role: JobClerk
+  #      time: 36000 # DeltaV - 10 hours
+  - !type:RoleTimeRequirement
+    role: JobLawyer
+    time: 36000 # 10 hours
+  - !type:RoleTimeRequirement
+    role: JobProsecutor
+    time: 36000 # 10 hours
+  - !type:OverallPlaytimeRequirement
+    time: 90000 # 25 hours
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 20
   startingGear: CJGear
   icon: "JobIconChiefJustice"
@@ -37,7 +36,7 @@
     implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
-      - type: CommandStaff
+    - type: CommandStaff
   - !type:AddComponentSpecial
     components:
     - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/clerk.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/clerk.yml
@@ -5,16 +5,15 @@
   playTimeTracker: JobClerk
   antagAdvantage: 2 # DeltaV - Reduced TC: Security Radio and Access
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:OverallPlaytimeRequirement
-#      time: 36000 # 10 hrs
-#    - !type:RoleTimeRequirement
-#      role: JobLawyer
-#      time: 36000 # 10 hours
-#    - !type:RoleTimeRequirement
-#      role: JobProsecutor
-#      time: 36000 # 10 hours
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Justice roles
+  - !type:OverallPlaytimeRequirement
+    time: 36000 # 10 hrs
+  - !type:RoleTimeRequirement
+    role: JobLawyer
+    time: 36000 # 10 hours
+  - !type:RoleTimeRequirement
+    role: JobProsecutor
+    time: 36000 # 10 hours
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Justice roles
   startingGear: ClerkGear
   icon: "JobIconClerk"
   requireAdminNotify: true

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/prosecutor.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/prosecutor.yml
@@ -4,13 +4,12 @@
   description: job-description-prosecutor
   playTimeTracker: JobProsecutor
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:OverallPlaytimeRequirement
-#      time: 36000 # 10 hrs
-#    - !type:DepartmentTimeRequirement # DeltaV - Security dept time requirement
-#      department: Security
-#      time: 21600 # 6 hours
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Justice roles
+  - !type:OverallPlaytimeRequirement
+    time: 36000 # 10 hrs
+  - !type:DepartmentTimeRequirement # DeltaV - Security dept time requirement
+    department: Security
+    time: 21600 # 6 hours
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Justice roles
   startingGear: ProsecutorGear
   icon: "JobIconProsecutor"
   supervisors: job-supervisors-cj
@@ -31,9 +30,9 @@
     ears: ClothingHeadsetJustice
     # TODO add copy of space law
   inhand:
-    - BriefcaseBrownFilled
-    #innerClothingSkirt: ClothingUniformJumpskirtProsecutor
-    #satchel: ClothingBackpackSatchelFilled
-    #duffelbag: ClothingBackpackDuffelFilled
+  - BriefcaseBrownFilled
+  #innerClothingSkirt: ClothingUniformJumpskirtProsecutor
+  #satchel: ClothingBackpackSatchelFilled
+  #duffelbag: ClothingBackpackDuffelFilled
 
 

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medical_borg.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medical_borg.yml
@@ -1,17 +1,15 @@
-
 - type: job
   id: MedicalBorg
   name: job-name-medical-borg
   description: job-description-medical-borg
   playTimeTracker: JobMedicalBorg
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:OverallPlaytimeRequirement
-#      time: 108000 #30 hrs
-#    - !type:DepartmentTimeRequirement
-#      department: Medical
-#      time: 21600 #6 hrs
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
+  - !type:OverallPlaytimeRequirement
+    time: 108000 #30 hrs
+  - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 21600 #6 hrs
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all higher risk roles
   canBeAntag: false
   icon: JobIconMedicalBorg
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medical_borg.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medical_borg.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobMedicalBorg
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 108000 #30 hrs
+    time: 216000 #60 hrs
   - !type:DepartmentTimeRequirement
     department: Medical
     time: 21600 #6 hrs

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
@@ -4,14 +4,13 @@
   description: job-description-brigmedic
   playTimeTracker: JobBrigmedic
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:DepartmentTimeRequirement
-#      department: Medical
-#      time: 21600 # 6 hrs
-#    - !type:RoleTimeRequirement # DeltaV - JobSecurityOfficer time requirement
-#      role: JobSecurityOfficer
-#      time: 21600 # DeltaV - 6 hrs
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Security roles
+  - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 21600 # 6 hrs
+  - !type:RoleTimeRequirement # DeltaV - JobSecurityOfficer time requirement
+    role: JobSecurityOfficer
+    time: 21600 # DeltaV - 6 hrs
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Security roles
   startingGear: CorpsmanGear
   icon: "JobIconBrigmedic"
   supervisors: job-supervisors-hos
@@ -34,7 +33,7 @@
 - type: startingGear
   id: CorpsmanGear # see Prototypes/Roles/Jobs/Fun/misc_startinggear.yml for "BrigmedicGear"
   equipment:
-#    eyes: ClothingEyesHudMedical
+    #    eyes: ClothingEyesHudMedical
     outerClothing: ClothingOuterCoatLabCorpsman
     id: CorpsmanPDA
     ears: ClothingHeadsetBrigmedic

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -19,7 +19,7 @@
     - state: active
   - type: Reactive # Nyanotrasen - Holy Water affects Revenants
     groups:
-      Acidic: [Touch]
+      Acidic: [ Touch ]
   - type: Clickable
   - type: StatusEffects
     allowed:
@@ -47,8 +47,8 @@
   - type: Eye
     drawFov: false
     visMask:
-      - Normal
-      - Ghost
+    - Normal
+    - Ghost
   - type: ContentEye
     maxZoom: 1.2, 1.2
   - type: DoAfter

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -4,14 +4,11 @@
   description: job-description-mantis
   playTimeTracker: JobForensicMantis
   requirements:
-    # Echo Station: Remove most playtime requirements
-#    - !type:OverallPlaytimeRequirement
-#      time: 18000
-#    - !type:DepartmentTimeRequirement
-#      department: Epistemics # DeltaV - Epistemics Department replacing Science
-#      time: 3600
-    - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
-      time: 14400 # 4 hours
+  - !type:OverallPlaytimeRequirement
+    time: 18000
+  - !type:DepartmentTimeRequirement
+    department: Epistemics # DeltaV - Epistemics Department replacing Science
+    time: 3600
   startingGear: ForensicMantisGear
   icon: "JobIconForensicMantis"
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
@@ -4,20 +4,19 @@
   description: job-description-guard
   playTimeTracker: JobPrisonGuard
   requirements:
-    # Echo Station: Remove most playtime requirements
-#    - !type:OverallPlaytimeRequirement
-#      time: 18000
-#    - !type:DepartmentTimeRequirement
-#      department: Security
-#      time: 14400
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
+  - !type:OverallPlaytimeRequirement
+    time: 18000
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 14400
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   startingGear: PrisonGuardGear
   alwaysUseSpawner: true
   canBeAntag: false
   icon: "JobIconPrisonGuard"
   supervisors: job-supervisors-warden
   setPreference: true
-#  whitelistRequired: true
+  #  whitelistRequired: true
   access:
   - Security
   #- Brig #Delta V: Removed brig access

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
@@ -9,13 +9,12 @@
   icon: "JobIconGladiator"
   supervisors: job-supervisors-security
   setPreference: true
-#  whitelistRequired: true
+  #  whitelistRequired: true
   requirements:
-    # Echo Station: Remove most playtime requirements
-#    - !type:DepartmentTimeRequirement
-#      department: Security
-#      time: 21600
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 21600
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
@@ -6,14 +6,13 @@
   startingGear: PrisonerGear
   alwaysUseSpawner: true
   canBeAntag: false
-#  whitelistRequired: true
+  #  whitelistRequired: true
   icon: "JobIconPrisoner"
   supervisors: job-supervisors-security
   requirements:
-    # Echo Station: Remove most playtime requirements
-#    - !type:DepartmentTimeRequirement
-#      department: Security
-#      time: 21600
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 21600
 
 - type: startingGear
   id: PrisonerGear

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -5,8 +5,7 @@
   setPreference: false
   objective: roles-antag-space-ninja-objective
   requirements:
-    # Echo Station: Remove most playtime requirements
-#  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
-#    time: 259200 # DeltaV - 72 hours
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
+  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
+    time: 259200 # DeltaV - 72 hours
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   guides: [ SpaceNinja ]

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -5,18 +5,17 @@
   setPreference: true
   objective: roles-antag-nuclear-operative-objective
   requirements:
-    # Echo Station: Remove most playtime requirements
-#  - !type:OverallPlaytimeRequirement
-#    time: 108000 # DeltaV - 30 hours
-#  - !type:DepartmentTimeRequirement # DeltaV - engi dept time requirement
-#    department: Engineering
-#    time: 7200 # DeltaV - 2 hours
-#  - !type:RoleTimeRequirement # DeltaV - salvage time requirement
-#    role: JobSalvageSpecialist
-#    time: 7200 # DeltaV - 2 hours
-#  - !type:DepartmentTimeRequirement # DeltaV - Security dept time requirement
-#    department: Security
-#    time: 36000 # DeltaV - 10 hours
+  - !type:OverallPlaytimeRequirement
+    time: 108000 # DeltaV - 30 hours
+  - !type:DepartmentTimeRequirement # DeltaV - engi dept time requirement
+    department: Engineering
+    time: 7200 # DeltaV - 2 hours
+  - !type:RoleTimeRequirement # DeltaV - salvage time requirement
+    role: JobSalvageSpecialist
+    time: 7200 # DeltaV - 2 hours
+  - !type:DepartmentTimeRequirement # DeltaV - Security dept time requirement
+    department: Security
+    time: 36000 # DeltaV - 10 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   guides: [ NuclearOperatives ]
 
@@ -27,12 +26,11 @@
   setPreference: true
   objective: roles-antag-nuclear-operative-agent-objective
   requirements:
-    # Echo Station: Remove most playtime requirements
-#  - !type:OverallPlaytimeRequirement
-#    time: 108000 # DeltaV - 30 hours
-#  - !type:DepartmentTimeRequirement # DeltaV - Medical dept time requirement
-#    department: Medical
-#    time: 36000 # DeltaV - 10 hours
+  - !type:OverallPlaytimeRequirement
+    time: 108000 # DeltaV - 30 hours
+  - !type:DepartmentTimeRequirement # DeltaV - Medical dept time requirement
+    department: Medical
+    time: 36000 # DeltaV - 10 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   guides: [ NuclearOperatives ]
 
@@ -43,14 +41,13 @@
   setPreference: true
   objective: roles-antag-nuclear-operative-commander-objective
   requirements:
-    # Echo Station: Remove most playtime requirements
-#    - !type:OverallPlaytimeRequirement
-#      time: 216000 # DeltaV - 60 hours
-#    - !type:DepartmentTimeRequirement # DeltaV - Security dept time requirement
-#      department: Security
-#      time: 36000 # DeltaV - 10 hours
-#    - !type:DepartmentTimeRequirement # DeltaV - Command dept time requirement
-#      department: Command
-#      time: 36000 # DeltaV - 10 hours
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
+  - !type:OverallPlaytimeRequirement
+    time: 216000 # DeltaV - 60 hours
+  - !type:DepartmentTimeRequirement # DeltaV - Security dept time requirement
+    department: Security
+    time: 36000 # DeltaV - 10 hours
+  - !type:DepartmentTimeRequirement # DeltaV - Command dept time requirement
+    department: Command
+    time: 36000 # DeltaV - 10 hours
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   guides: [ NuclearOperatives ]

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -5,12 +5,11 @@
   setPreference: true
   objective: roles-antag-rev-head-objective
   requirements:
-    # Echo Station: Remove most playtime requirements
-#  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
-#    time: 172800 # DeltaV - 48 hours
-#  - !type:DepartmentTimeRequirement # DeltaV - Command dept time requirement
-#    department: Command
-#    time: 36000 # DeltaV - 10 hours
+  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
+    time: 172800 # DeltaV - 48 hours
+  - !type:DepartmentTimeRequirement # DeltaV - Command dept time requirement
+    department: Command
+    time: 36000 # DeltaV - 10 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
   guides: [ Revolutionaries ]
 

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -6,7 +6,6 @@
   objective: roles-antag-syndicate-agent-objective
   guides: [ Traitors ]
   requirements:
-    # Echo Station: Remove most playtime requirements
-#  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
-#    time: 86400 # DeltaV - 24 hours
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles
+  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
+    time: 86400 # DeltaV - 24 hours
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Antag roles

--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -5,9 +5,8 @@
   setPreference: true
   objective: roles-antag-initial-infected-objective
   requirements:
-    # Echo Station: Remove most playtime requirements
-#  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
-#    time: 43200 # DeltaV - 12 hours
+  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
+    time: 43200 # DeltaV - 12 hours
   # Echo Station: Okay, fine, this one anyone can do
   guides: [ Zombies ]
 

--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -5,9 +5,8 @@
   playTimeTracker: JobCargoTechnician
   startingGear: CargoTechGear
   requirements:
-    # Echo Station: Remove most time requirements
-#  - !type:OverallPlaytimeRequirement # DeltaV
-#    time: 3600 # 1 hr
+  - !type:OverallPlaytimeRequirement # DeltaV
+    time: 3600 # 1 hr
   icon: "JobIconCargoTechnician"
   supervisors: job-supervisors-qm
   access:

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -5,20 +5,19 @@
   playTimeTracker: JobQuartermaster
   antagAdvantage: 6 # DeltaV - Reduced TC: Head of Staff
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:RoleTimeRequirement
-#      role: JobCargoTechnician
-#      time: 21600 #6 hrs
-#    - !type:RoleTimeRequirement
-#      role: JobSalvageSpecialist
-#      time: 10800 #3 hrs
-#    - !type:RoleTimeRequirement # DeltaV - Courier role time requirement
-#      role: JobCourier
-#      time: 7200 # 2 hours
-#    - !type:DepartmentTimeRequirement
-#      department: Logistics # DeltaV - Logistics Department replacing Cargo
-#      time: 43200 #DeltaV 12 hours
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
+  - !type:RoleTimeRequirement
+    role: JobCargoTechnician
+    time: 21600 #6 hrs
+  - !type:RoleTimeRequirement
+    role: JobSalvageSpecialist
+    time: 10800 #3 hrs
+  - !type:RoleTimeRequirement # DeltaV - Courier role time requirement
+    role: JobCourier
+    time: 7200 # 2 hours
+  - !type:DepartmentTimeRequirement
+    department: Logistics # DeltaV - Logistics Department replacing Cargo
+    time: 43200 #DeltaV 12 hours
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"
@@ -39,7 +38,7 @@
     implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
-      - type: CommandStaff
+    - type: CommandStaff
 
 - type: startingGear
   id: QuartermasterGear

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -17,6 +17,8 @@
   - !type:DepartmentTimeRequirement
     department: Logistics # DeltaV - Logistics Department replacing Cargo
     time: 43200 #DeltaV 12 hours
+  - !type:OverallPlaytimeRequirement
+    time: 144000 #40 hrs
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10
   startingGear: QuartermasterGear

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -16,9 +16,7 @@
     time: 7200 # 2 hours
   - !type:DepartmentTimeRequirement
     department: Logistics # DeltaV - Logistics Department replacing Cargo
-    time: 43200 #DeltaV 12 hours
-  - !type:OverallPlaytimeRequirement
-    time: 144000 #40 hrs
+    time: 54000 # Echo Station: 15 hrs
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10
   startingGear: QuartermasterGear

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -5,14 +5,12 @@
   playTimeTracker: JobSalvageSpecialist
   antagAdvantage: 8 # DeltaV - Reduced TC: External Access + Free hardsuit and weapons
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:DepartmentTimeRequirement
-#      department: Logistics # DeltaV - Logistics Department replacing Cargo
-#      time: 21600 #DeltaV 6 hrs
+  - !type:DepartmentTimeRequirement
+    department: Logistics # DeltaV - Logistics Department replacing Cargo
+    time: 21600 #DeltaV 6 hrs
   #  - !type:OverallPlaytimeRequirement #DeltaV
   #    time: 36000 #10 hrs
-    - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
-      time: 14400 # 4 hours
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting (access to weapons)
   icon: "JobIconShaftMiner"
   startingGear: SalvageSpecialistGear
   supervisors: job-supervisors-qm

--- a/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
@@ -5,8 +5,9 @@
   playTimeTracker: JobBartender
   antagAdvantage: 1 # DeltaV - Shotgun, and free room
   requirements:
-    - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
-      time: 14400 # 4 hours
+  - !type:DepartmentTimeRequirement
+    department: Civilian
+    time: 3600 #DeltaV
   startingGear: BartenderGear
   icon: "JobIconBartender"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Civilian/botanist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/botanist.yml
@@ -6,6 +6,9 @@
   startingGear: BotanistGear
   icon: "JobIconBotanist"
   supervisors: job-supervisors-hop
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 7200 # Echo Station - 2 hrs to protect against raiders
   access:
   - Service
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -5,8 +5,9 @@
   playTimeTracker: JobChaplain
   antagAdvantage: 4 # DeltaV - Protolathe, Increased Psionics, Gib machine, anomaly access, glimmer factor
   requirements:
-    - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
-      time: 14400 # 4 hours
+  - !type:DepartmentTimeRequirement
+    department: Epistemics # DeltaV - Epistemics Department replacing Science
+    time: 14400 #DeltaV 4 hours
   startingGear: ChaplainGear
   icon: "JobIconChaplain"
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -4,8 +4,9 @@
   description: job-description-chef
   playTimeTracker: JobChef
   requirements:
-    - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
-      time: 14400 # 4 hours
+  - !type:DepartmentTimeRequirement
+    department: Civilian
+    time: 3600 #DeltaV 1 hour
   startingGear: ChefGear
   icon: "JobIconChef"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobJanitor
   requirements:
   - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
-    time: 14400 # 4 hours
+    time: 7200 # 2 hours
   startingGear: JanitorGear
   icon: "JobIconJanitor"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
@@ -4,8 +4,8 @@
   description: job-description-janitor
   playTimeTracker: JobJanitor
   requirements:
-    - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
-      time: 14400 # 4 hours
+  - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
+    time: 14400 # 4 hours
   startingGear: JanitorGear
   icon: "JobIconJanitor"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -5,13 +5,12 @@
   playTimeTracker: JobLawyer
   antagAdvantage: 4 # DeltaV - Reduced TC: Security Radio and Access
   requirements:
-    # Echo Station: Remove most playtime requirements
-#    - !type:OverallPlaytimeRequirement
-#      time: 36000 # 10 hrs
-#    - !type:DepartmentTimeRequirement # DeltaV - Security dept time requirement
-#      department: Security
-#      time: 14400 # 4 hours
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Justice roles
+  - !type:OverallPlaytimeRequirement
+    time: 36000 # 10 hrs
+  - !type:DepartmentTimeRequirement # DeltaV - Security dept time requirement
+    department: Security
+    time: 14400 # 4 hours
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Justice roles
   startingGear: LawyerGear
   icon: "JobIconLawyer"
   supervisors: job-supervisors-cj  # Delta V - Change supervisor to chief justice
@@ -29,4 +28,4 @@
     ears: ClothingHeadsetJustice # DeltaV - Added lawyer to justice department
     # TODO add copy of space law
   inhand:
-    - BriefcaseBrownFilled
+  - BriefcaseBrownFilled

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -3,9 +3,6 @@
   name: job-name-librarian
   description: job-description-librarian
   playTimeTracker: JobLibrarian
-  requirements:
-    - !type:OverallPlaytimeRequirement #DeltaV
-      time: 3600 # 1 hr
   startingGear: LibrarianGear
   icon: "JobIconLibrarian"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobMusician
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 7200 # DeltaV - 2 hours
+      time: 3600 # Echo Station - 1 hour
   startingGear: MusicianGear
   icon: "JobIconMusician"
   supervisors: job-supervisors-hire

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -3,6 +3,9 @@
   name: job-name-musician
   description: job-description-musician
   playTimeTracker: JobMusician
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 7200 # DeltaV - 2 hours
   startingGear: MusicianGear
   icon: "JobIconMusician"
   supervisors: job-supervisors-hire

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -3,9 +3,6 @@
   name: job-name-serviceworker
   description: job-description-serviceworker
   playTimeTracker: JobServiceWorker
-  requirements:
-    - !type:OverallPlaytimeRequirement
-      time: 7200 # DeltaV - 2 hours
   startingGear: ServiceWorkerGear
   icon: "JobIconServiceWorker"
   supervisors: job-supervisors-service

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -4,28 +4,27 @@
   description: job-description-captain
   playTimeTracker: JobCaptain
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:DepartmentTimeRequirement
-#      department: Logistics # DeltaV - Logistics Department replacing Cargo
-#      time: 18000 # DeltaV - 5 hours
-#    - !type:DepartmentTimeRequirement
-#      department: Engineering
-#      time: 18000 # DeltaV - 5 hours
-#    - !type:DepartmentTimeRequirement
-#      department: Medical
-#      time: 18000 # DeltaV - 5 hours
-#    - !type:DepartmentTimeRequirement
-#      department: Security
-#      time: 18000 # DeltaV - 5 hours
-#    - !type:DepartmentTimeRequirement # DeltaV - Epistemics dept time requirement
-#      department: Epistemics # DeltaV - Epistemics Department replacing Science
-#      time: 18000 # 5 hours
-#    - !type:DepartmentTimeRequirement
-#      department: Command
-#      time: 108000 # DeltaV - 30 hours
-#    - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
-#      time: 108000 # 30 hours
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
+  - !type:DepartmentTimeRequirement
+    department: Logistics # DeltaV - Logistics Department replacing Cargo
+    time: 18000 # DeltaV - 5 hours
+  - !type:DepartmentTimeRequirement
+    department: Engineering
+    time: 18000 # DeltaV - 5 hours
+  - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 18000 # DeltaV - 5 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 18000 # DeltaV - 5 hours
+  - !type:DepartmentTimeRequirement # DeltaV - Epistemics dept time requirement
+    department: Epistemics # DeltaV - Epistemics Department replacing Science
+    time: 18000 # 5 hours
+  - !type:DepartmentTimeRequirement
+    department: Command
+    time: 108000 # DeltaV - 30 hours
+  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
+    time: 108000 # 30 hours
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   whitelisted: true # Echo Station: Require explicit role whitelisting
   weight: 20
   startingGear: CaptainGear
@@ -42,7 +41,7 @@
     implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
-      - type: CommandStaff
+    - type: CommandStaff
   - !type:AddComponentSpecial
     components:
     - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -17,8 +17,6 @@
   - !type:DepartmentTimeRequirement # DeltaV - Civilian dept time requirement
     department: Civilian
     time: 72000 # 20 hours
-  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
-    time: 108000 # 30 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10 # DeltaV - Changed HoP weight from 20 to 10 due to them not being more important than other Heads
   startingGear: HoPGear

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -5,20 +5,19 @@
   playTimeTracker: JobHeadOfPersonnel
   antagAdvantage: 6 # DeltaV - Reduced TC: Head of Staff
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:RoleTimeRequirement
-#      role: JobChef
-#      time: 14400 # DeltaV - 4 hours
-#    - !type:RoleTimeRequirement
-#      role: JobBartender
-#      time: 14400 # DeltaV - 4 hours
-#    - !type:RoleTimeRequirement
-#      role: JobJanitor
-#      time: 14400 # DeltaV - 4 hours
-#    - !type:DepartmentTimeRequirement # DeltaV - Civilian dept time requirement
-#      department: Civilian
-#      time: 72000 # 20 hours
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
+  - !type:RoleTimeRequirement
+    role: JobChef
+    time: 14400 # DeltaV - 4 hours
+  - !type:RoleTimeRequirement
+    role: JobBartender
+    time: 14400 # DeltaV - 4 hours
+  - !type:RoleTimeRequirement
+    role: JobJanitor
+    time: 14400 # DeltaV - 4 hours
+  - !type:DepartmentTimeRequirement # DeltaV - Civilian dept time requirement
+    department: Civilian
+    time: 72000 # 20 hours
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10 # DeltaV - Changed HoP weight from 20 to 10 due to them not being more important than other Heads
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"
@@ -34,7 +33,7 @@
   - Janitor
   - Theatre
   - Kitchen
-#  - Chapel
+  #  - Chapel
   - Hydroponics
   - External
   - Cryogenics
@@ -42,17 +41,17 @@
   # As of 15/03/23 they can't do that so here's MOST of the rest of the access levels.
   # Head level access that isn't their own was deliberately left out, get AA from the captain instead.
   # Delta V - fuck all of this HoP is a service role
-#  - Chemistry
-#  - Engineering
-#  - Research
-#  - Detective
-#  - Salvage
-#  - Security # NoooOoOo!! My HoPcurity!1
-#  - Brig
-#  - Lawyer # Lawyer is now part of the justice dept
-#  - Cargo
-#  - Atmospherics
-#  - Medical
+  #  - Chemistry
+  #  - Engineering
+  #  - Research
+  #  - Detective
+  #  - Salvage
+  #  - Security # NoooOoOo!! My HoPcurity!1
+  #  - Brig
+  #  - Lawyer # Lawyer is now part of the justice dept
+  #  - Cargo
+  #  - Atmospherics
+  #  - Medical
   - Boxer # DeltaV - Add Boxer access
   - Clown # DeltaV - Add Clown access
   - Library # DeltaV - Add Library access
@@ -65,7 +64,7 @@
     implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
-      - type: CommandStaff
+    - type: CommandStaff
   - !type:AddComponentSpecial
     components:
     - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -17,6 +17,8 @@
   - !type:DepartmentTimeRequirement # DeltaV - Civilian dept time requirement
     department: Civilian
     time: 72000 # 20 hours
+  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
+    time: 108000 # 30 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10 # DeltaV - Changed HoP weight from 20 to 10 due to them not being more important than other Heads
   startingGear: HoPGear

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Engineering
-    time: 36000 # Echo Station: 5 hours
+    time: 36000 # DeltaV - 10 hours
   startingGear: AtmosphericTechnicianGear
   icon: "JobIconAtmosphericTechnician"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -5,12 +5,9 @@
   playTimeTracker: JobAtmosphericTechnician
   antagAdvantage: 4 # DeltaV - Reduced TC: External Access + Fireaxe + Free Hardsuit
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:DepartmentTimeRequirement
-#      department: Engineering
-#      time: 36000 # Echo Station: 5 hours
-  - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
-    time: 14400 # 4 hours
+  - !type:DepartmentTimeRequirement
+    department: Engineering
+    time: 36000 # Echo Station: 5 hours
   startingGear: AtmosphericTechnicianGear
   icon: "JobIconAtmosphericTechnician"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -6,10 +6,15 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobAtmosphericTechnician
-    time: 14400 # 4 hrs
-  - !type:RoleTimeRequirement # DeltaV - No Station Engineer time requirement
-    role: JobStationEngineer
-    time: 14400 # 4 hrs
+    time: 36000 # DeltaV - 10 hours
+  #    - !type:RoleTimeRequirement # DeltaV - No Station Engineer time requirement
+  #      role: JobStationEngineer
+  #      time: 21600 #6 hrs
+  - !type:DepartmentTimeRequirement
+    department: Engineering
+    time: 90000 # DeltaV - 25 hours
+  #    - !type:OverallPlaytimeRequirement
+  #      time: 72000 # DeltaV - 20 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10
   startingGear: ChiefEngineerGear

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -4,14 +4,13 @@
   description: job-description-ce
   playTimeTracker: JobChiefEngineer
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:RoleTimeRequirement
-#      role: JobAtmosphericTechnician
-#      time: 14400 # 4 hrs
-#    - !type:RoleTimeRequirement # DeltaV - No Station Engineer time requirement
-#      role: JobStationEngineer
-#      time: 14400 # 4 hrs
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
+  - !type:RoleTimeRequirement
+    role: JobAtmosphericTechnician
+    time: 14400 # 4 hrs
+  - !type:RoleTimeRequirement # DeltaV - No Station Engineer time requirement
+    role: JobStationEngineer
+    time: 14400 # 4 hrs
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"
@@ -31,7 +30,7 @@
     implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
-      - type: CommandStaff
+    - type: CommandStaff
   - !type:AddComponentSpecial
     components:
     - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -13,8 +13,6 @@
   - !type:DepartmentTimeRequirement
     department: Engineering
     time: 90000 # DeltaV - 25 hours
-  #    - !type:OverallPlaytimeRequirement
-  #      time: 72000 # DeltaV - 20 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10
   startingGear: ChiefEngineerGear

--- a/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
@@ -7,17 +7,16 @@
   canBeAntag: true # Echo Station: Yes, seniors can be antags.
   antagAdvantage: 6 # Echo Station: 14 TC.
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:RoleTimeRequirement
-#      role: JobAtmosphericTechnician
-#      time: 43200 #12 hrs
-#    - !type:RoleTimeRequirement
-#      role: JobStationEngineer
-#      time: 43200 #12 hrs
-#    - !type:DepartmentTimeRequirement
-#      department: Engineering
-#      time: 108000 # 30 hrs
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Senior roles
+  - !type:RoleTimeRequirement
+    role: JobAtmosphericTechnician
+    time: 43200 #12 hrs
+  - !type:RoleTimeRequirement
+    role: JobStationEngineer
+    time: 43200 #12 hrs
+  - !type:DepartmentTimeRequirement
+    department: Engineering
+    time: 108000 # 30 hrs
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Senior roles
   startingGear: SeniorEngineerGear
   icon: "JobIconSeniorEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
@@ -9,13 +9,13 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobAtmosphericTechnician
-    time: 43200 #12 hrs
+    time: 21600 #6 hrs
   - !type:RoleTimeRequirement
     role: JobStationEngineer
-    time: 43200 #12 hrs
+    time: 21600 #6 hrs
   - !type:DepartmentTimeRequirement
     department: Engineering
-    time: 108000 # 30 hrs
+    time: 216000 # 60 hrs
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Senior roles
   startingGear: SeniorEngineerGear
   icon: "JobIconSeniorEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -5,12 +5,9 @@
   playTimeTracker: JobStationEngineer
   antagAdvantage: 3 # DeltaV - Reduced TC: External Access + Engineering
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:DepartmentTimeRequirement
-#      department: Engineering
-#      time: 14400 #4 hrs
-    - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
-      time: 14400 # 4 hours
+  - !type:DepartmentTimeRequirement
+    department: Engineering
+    time: 14400 #4 hrs
   startingGear: StationEngineerGear
   icon: "JobIconStationEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -5,8 +5,8 @@
   playTimeTracker: JobTechnicalAssistant
   antagAdvantage: 3 # DeltaV - Reduced TC: External Access + Engineering
   requirements:
-    - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
-      time: 14400 # 4 hours
+  - !type:OverallPlaytimeRequirement # DeltaV - to prevent griefers from taking the role.
+    time: 14400 # 4 hours
     # - !type:DepartmentTimeRequirement # DeltaV - Removes time limit
     #   department: Engineering
     #   time: 54000 #15 hrs

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -5,10 +5,9 @@
   playTimeTracker: JobChemist
   antagAdvantage: 4 # DeltaV - Synthesize any chem you want with little oversight.
   requirements:
-  - !type:WhitelistRequirement # Echo Station: Require server whitelisting higher risk roles
-#    - !type:DepartmentTimeRequirement
-#      department: Medical
-#      time: 14400 # DeltaV - 4 hours
+  - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 14400 # DeltaV - 4 hours
   startingGear: ChemistGear
   icon: "JobIconChemist"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Medical
-    time: 14400 # DeltaV - 4 hours
+    time: 28800 # DeltaV - 8 hours
   startingGear: ChemistGear
   icon: "JobIconChemist"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -9,16 +9,16 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobChemist
-    time: 14400 # 4 hrs
+    time: 21600 # 6 hrs
   - !type:RoleTimeRequirement
     role: JobMedicalDoctor
-    time: 14400 # 4 hrs
+    time: 21600 # 6 hrs
   - !type:RoleTimeRequirement
     role: JobParamedic
-    time: 14400 # 4 hrs
+    time: 21600 # 6 hrs
   - !type:DepartmentTimeRequirement
     department: Medical
-    time: 36000 # 10 hrs
+    time: 43200 # DeltaV - 12 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10
   startingGear: CMOGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -19,6 +19,8 @@
   - !type:DepartmentTimeRequirement
     department: Medical
     time: 43200 # DeltaV - 12 hours
+  - !type:OverallPlaytimeRequirement
+    time: 72000 # DeltaV - 20 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10
   startingGear: CMOGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -7,20 +7,19 @@
   playTimeTracker: JobChiefMedicalOfficer
   antagAdvantage: 6 # DeltaV - Reduced TC: Head of Staff
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:RoleTimeRequirement
-#      role: JobChemist
-#      time: 14400 # 4 hrs
-#    - !type:RoleTimeRequirement
-#      role: JobMedicalDoctor
-#      time: 14400 # 4 hrs
-#    - !type:RoleTimeRequirement
-#      role: JobParamedic
-#      time: 14400 # 4 hrs
-#    - !type:DepartmentTimeRequirement
-#      department: Medical
-#      time: 36000 # 10 hrs
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
+  - !type:RoleTimeRequirement
+    role: JobChemist
+    time: 14400 # 4 hrs
+  - !type:RoleTimeRequirement
+    role: JobMedicalDoctor
+    time: 14400 # 4 hrs
+  - !type:RoleTimeRequirement
+    role: JobParamedic
+    time: 14400 # 4 hrs
+  - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 36000 # 10 hrs
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"
@@ -42,7 +41,7 @@
     implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
-      - type: CommandStaff
+    - type: CommandStaff
   - !type:AddComponentSpecial
     components:
     - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -15,12 +15,10 @@
     time: 21600 # 6 hrs
   - !type:RoleTimeRequirement
     role: JobParamedic
-    time: 21600 # 6 hrs
+    time: 21600 # 4 hrs
   - !type:DepartmentTimeRequirement
     department: Medical
-    time: 43200 # DeltaV - 12 hours
-  - !type:OverallPlaytimeRequirement
-    time: 72000 # DeltaV - 20 hours
+    time: 54000 # Echo Station: 15 hrs
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10
   startingGear: CMOGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -4,12 +4,9 @@
   description: job-description-doctor
   playTimeTracker: JobMedicalDoctor
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:DepartmentTimeRequirement
-#      department: Medical
-#      time: 14400 #4 hrs
-    - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
-      time: 14400 # 4 hours
+  - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 14400 #4 hrs
   startingGear: DoctorGear
   icon: "JobIconMedicalDoctor"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -4,8 +4,6 @@
   description: job-description-intern
   playTimeTracker: JobMedicalIntern
   requirements:
-    - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
-      time: 14400 # 4 hours
     # - !type:DepartmentTimeRequirement # DeltaV - Removes time limit
     #   department: Medical
     #   time: 54000 # 15 hrs

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -5,9 +5,9 @@
   playTimeTracker: JobParamedic
   antagAdvantage: 2 # DeltaV - Reduced TC: External Access
   requirements:
-    - !type:RoleTimeRequirement
-     role: JobMedicalDoctor
-     time: 14400 #4 hrs
+    # - !type:RoleTimeRequirement # DeltaV - No Medical Doctor time requirement
+    #   role: JobMedicalDoctor
+    #   time: 14400 #4 hrs
     - !type:DepartmentTimeRequirement # DeltaV - Medical dept time requirement
       department: Medical
       time: 28800 # DeltaV - 8 hours

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -5,11 +5,9 @@
   playTimeTracker: JobParamedic
   antagAdvantage: 2 # DeltaV - Reduced TC: External Access
   requirements:
-#    - !type:RoleTimeRequirement
-#     role: JobMedicalDoctor
-#     time: 14400 #4 hrs
-    - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
-      time: 14400 # 4 hours
+    - !type:RoleTimeRequirement
+     role: JobMedicalDoctor
+     time: 14400 #4 hrs
   startingGear: ParamedicGear
   icon: "JobIconParamedic"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -8,6 +8,11 @@
     - !type:RoleTimeRequirement
      role: JobMedicalDoctor
      time: 14400 #4 hrs
+    - !type:DepartmentTimeRequirement # DeltaV - Medical dept time requirement
+      department: Medical
+      time: 28800 # DeltaV - 8 hours
+    # - !type:OverallPlaytimeRequirement # DeltaV - No playtime requirement
+    #   time: 54000 # 15 hrs
   startingGear: ParamedicGear
   icon: "JobIconParamedic"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -5,14 +5,14 @@
   playTimeTracker: JobParamedic
   antagAdvantage: 2 # DeltaV - Reduced TC: External Access
   requirements:
-    # - !type:RoleTimeRequirement # DeltaV - No Medical Doctor time requirement
-    #   role: JobMedicalDoctor
-    #   time: 14400 #4 hrs
-    - !type:DepartmentTimeRequirement # DeltaV - Medical dept time requirement
-      department: Medical
-      time: 28800 # DeltaV - 8 hours
-    # - !type:OverallPlaytimeRequirement # DeltaV - No playtime requirement
-    #   time: 54000 # 15 hrs
+  # - !type:RoleTimeRequirement # DeltaV - No Medical Doctor time requirement
+  #   role: JobMedicalDoctor
+  #   time: 14400 #4 hrs
+  - !type:DepartmentTimeRequirement # DeltaV - Medical dept time requirement
+    department: Medical
+    time: 28800 # DeltaV - 8 hours
+  # - !type:OverallPlaytimeRequirement # DeltaV - No playtime requirement
+  #   time: 54000 # 15 hrs
   startingGear: ParamedicGear
   icon: "JobIconParamedic"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
@@ -18,7 +18,7 @@
     time: 21600 #6 hrs
   - !type:DepartmentTimeRequirement
     department: Medical
-    time: 108000 # 30 hrs
+    time: 216000 # 60 hrs
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Senior roles
   startingGear: SeniorPhysicianGear
   icon: "JobIconSeniorPhysician"

--- a/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
@@ -12,7 +12,7 @@
     time: 21600 #6 hrs
   - !type:RoleTimeRequirement
     role: JobMedicalDoctor
-    time: 21600 #6 hrs
+    time: 43200 #12 hrs
   - !type:RoleTimeRequirement
     role: JobParamedic
     time: 21600 #6 hrs

--- a/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
@@ -7,19 +7,19 @@
   canBeAntag: true # Echo Station: Yes, seniors can be antags.
   antagAdvantage: 6 # Echo Station: 14 TC. Medical supplies, chem access, paramedic access, ..
   requirements:
-#    - !type:RoleTimeRequirement
-#      role: JobChemist
-#      time: 21600 #6 hrs
-#    - !type:RoleTimeRequirement
-#      role: JobMedicalDoctor
-#      time: 21600 #6 hrs
-#    - !type:RoleTimeRequirement
-#      role: JobParamedic
-#      time: 21600 #6 hrs
-#    - !type:DepartmentTimeRequirement
-#      department: Medical
-#      time: 108000 # 30 hrs
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Senior roles
+  - !type:RoleTimeRequirement
+    role: JobChemist
+    time: 21600 #6 hrs
+  - !type:RoleTimeRequirement
+    role: JobMedicalDoctor
+    time: 21600 #6 hrs
+  - !type:RoleTimeRequirement
+    role: JobParamedic
+    time: 21600 #6 hrs
+  - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 108000 # 30 hrs
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Senior roles
   startingGear: SeniorPhysicianGear
   icon: "JobIconSeniorPhysician"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobBorg
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 36000 #10 hrs
+    time: 216000 #60 hrs
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for higher risk roles
   canBeAntag: false
   icon: JobIconBorg

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -4,10 +4,9 @@
   description: job-description-borg
   playTimeTracker: JobBorg
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:OverallPlaytimeRequirement
-#      time: 36000 #10 hrs
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for higher risk roles
+  - !type:OverallPlaytimeRequirement
+    time: 36000 #10 hrs
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for higher risk roles
   canBeAntag: false
   icon: JobIconBorg
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -5,10 +5,10 @@
   playTimeTracker: JobResearchDirector
   antagAdvantage: 6 # DeltaV - Reduced TC: Head of Staff
   requirements:
-#    - !type:DepartmentTimeRequirement
-#      department: Epistemics # DeltaV - Epistemics Department replacing Science
-#      time: 36000 # 10 hrs
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
+  - !type:DepartmentTimeRequirement
+    department: Epistemics # DeltaV - Epistemics Department replacing Science
+    time: 36000 # 10 hrs
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"
@@ -33,7 +33,7 @@
     implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
-      - type: CommandStaff
+    - type: CommandStaff
 
 - type: startingGear
   id: ResearchDirectorGear

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -8,8 +8,6 @@
   - !type:DepartmentTimeRequirement
     department: Epistemics # DeltaV - Epistemics Department replacing Science
     time: 54000 # DeltaV - 15 hours
-  - !type:OverallPlaytimeRequirement
-    time: 72000 # DeltaV - 20 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10
   startingGear: ResearchDirectorGear

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -8,6 +8,8 @@
   - !type:DepartmentTimeRequirement
     department: Epistemics # DeltaV - Epistemics Department replacing Science
     time: 54000 # DeltaV - 15 hours
+  - !type:OverallPlaytimeRequirement
+    time: 72000 # DeltaV - 20 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10
   startingGear: ResearchDirectorGear

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Epistemics # DeltaV - Epistemics Department replacing Science
-    time: 36000 # 10 hrs
+    time: 54000 # DeltaV - 15 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Command roles
   weight: 10
   startingGear: ResearchDirectorGear

--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -5,10 +5,9 @@
   playTimeTracker: JobScientist
   antagAdvantage: 2 # DeltaV - Protolathe, anomaly stuff, glimmer factor.
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:DepartmentTimeRequirement
-#      department: Epistemics # DeltaV - Epistemics Department replacing Science
-#      time: 14400 #4 hrs
+  - !type:DepartmentTimeRequirement
+    department: Epistemics # DeltaV - Epistemics Department replacing Science
+    time: 14400 #4 hrs
   startingGear: ScientistGear
   icon: "JobIconScientist"
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Science/senior_researcher.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/senior_researcher.yml
@@ -7,11 +7,10 @@
   canBeAntag: true # Echo Station: Yes, seniors can be antags. No penalty for senior here.
   antagAdvantage: 2 # Echo Station: Same penalty as scientist.
   requirements:
-    # Echo Station: Remove most playtime requirements
-#    - !type:DepartmentTimeRequirement
-#      department: Epistemics # DeltaV - Epistemics Department replacing Science
-#      time: 108000 # 10 hrs
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Senior roles
+  - !type:DepartmentTimeRequirement
+    department: Epistemics # DeltaV - Epistemics Department replacing Science
+    time: 108000 # 30 hrs
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Senior roles
   startingGear: SeniorResearcherGear
   icon: "JobIconSeniorResearcher"
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Science/senior_researcher.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/senior_researcher.yml
@@ -9,7 +9,7 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Epistemics # DeltaV - Epistemics Department replacing Science
-    time: 108000 # 30 hrs
+    time: 216000 #60 hrs
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all Senior roles
   startingGear: SeniorResearcherGear
   icon: "JobIconSeniorResearcher"

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -4,14 +4,10 @@
   description: job-description-detective
   playTimeTracker: JobDetective
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:DepartmentTimeRequirement
-#      department: Security
-#      time: 7200 # 2hrs
-#    - !type:RoleTimeRequirement # DeltaV - JobSecurityOfficer time requirement
-#      role: JobSecurityOfficer
-#      time: 21600 # 6 hrs
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
+  - !type:RoleTimeRequirement # DeltaV - JobSecurityOfficer time requirement
+    role: JobSecurityOfficer
+    time: 21600 # DeltaV - 6 hrs
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos
@@ -30,7 +26,7 @@
 - type: startingGear
   id: DetectiveGear
   equipment:
-#    eyes: ClothingEyesGlassesSecurity # DeltaV
+    #    eyes: ClothingEyesGlassesSecurity # DeltaV
     id: DetectivePDA
     ears: ClothingHeadsetSecurity
     belt: ClothingBeltHolsterFilled

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -4,17 +4,16 @@
   description: job-description-hos
   playTimeTracker: JobHeadOfSecurity
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:DepartmentTimeRequirement
-#      department: Security
-#      time: 36000 # 10 hours
-#    - !type:RoleTimeRequirement
-#      role: JobWarden
-#      time: 144000 # 4 hours
-#    - !type:DepartmentTimeRequirement
-#      department: Command
-#      time: 144000 # 4 hours
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 36000 # 10 hours
+  - !type:RoleTimeRequirement
+    role: JobWarden
+    time: 144000 # 4 hours
+  - !type:DepartmentTimeRequirement
+    department: Command
+    time: 144000 # 4 hours
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   whitelisted: true # Echo Station: Also require role specific whitelist
   weight: 10
   startingGear: HoSGear
@@ -39,7 +38,7 @@
     implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
-      - type: CommandStaff
+    - type: CommandStaff
   - !type:AddComponentSpecial
     components:
     - type: PsionicBonusChance #Nyano - Summary: makes it more likely to become psionic.
@@ -48,7 +47,7 @@
 - type: startingGear
   id: HoSGear
   equipment:
-#    eyes: ClothingEyesGlassesSecurity # DeltaV
+    #    eyes: ClothingEyesGlassesSecurity # DeltaV
     id: HoSPDA
     gloves: ClothingHandsGlovesCombat
     ears: ClothingHeadsetAltSecurity

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -14,7 +14,7 @@
     department: Command
     time: 36000 # 10 hours
   - !type:OverallPlaytimeRequirement
-    time: 90000 # 25 hours
+    time: 90000 # DeltaV - 25 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   whitelisted: true # Echo Station: Also require role specific whitelist
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -13,8 +13,6 @@
   - !type:DepartmentTimeRequirement
     department: Command
     time: 36000 # 10 hours
-  - !type:OverallPlaytimeRequirement
-    time: 90000 # DeltaV - 25 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   whitelisted: true # Echo Station: Also require role specific whitelist
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -13,6 +13,8 @@
   - !type:DepartmentTimeRequirement
     department: Command
     time: 36000 # 10 hours
+  - !type:OverallPlaytimeRequirement
+    time: 90000 # 25 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   whitelisted: true # Echo Station: Also require role specific whitelist
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -6,13 +6,13 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Security
-    time: 36000 # 10 hours
+    time: 72000 # 20 hours
   - !type:RoleTimeRequirement
     role: JobWarden
-    time: 144000 # 4 hours
+    time: 18000 # 10 hours
   - !type:DepartmentTimeRequirement
     department: Command
-    time: 144000 # 4 hours
+    time: 36000 # 10 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   whitelisted: true # Echo Station: Also require role specific whitelist
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -4,14 +4,13 @@
   description: job-description-cadet
   playTimeTracker: JobSecurityCadet
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:OverallPlaytimeRequirement
-#      time: 21600 # DeltaV - 6 hours
-#    - !type:DepartmentTimeRequirement # DeltaV - Removes time limit
-#      department: Security
-#      time: 54000 #15 hrs
-#      inverted: true # stop playing intern if you're good at security!
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
+  - !type:OverallPlaytimeRequirement
+    time: 21600 # DeltaV - 6 hours
+  #    - !type:DepartmentTimeRequirement # DeltaV - Removes time limit
+  #      department: Security
+  #      time: 54000 #15 hrs
+  #      inverted: true # stop playing intern if you're good at security!
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security
@@ -31,10 +30,10 @@
   id: SecurityCadetGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitCadet # DeltaV - precious uniform budget has been allocated to real security uniforms for cadets. not good ones though.
-#    shoes: ClothingShoesBootsCombatFilled # DeltaV
-#    outerClothing: ClothingOuterArmorDuraVest # DeltaV
+    #    shoes: ClothingShoesBootsCombatFilled # DeltaV
+    #    outerClothing: ClothingOuterArmorDuraVest # DeltaV
     id: SecurityCadetPDA
     ears: ClothingHeadsetSecurity
     belt: ClothingBeltSecurityFilled
-#    pocket1: WeaponPistolMk58Nonlethal # DeltaV - Security Cadet doesn't spawn with a gun
+    #    pocket1: WeaponPistolMk58Nonlethal # DeltaV - Security Cadet doesn't spawn with a gun
     pocket2: BookSecurity

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -6,10 +6,10 @@
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 21600 # DeltaV - 6 hours
-  #    - !type:DepartmentTimeRequirement # DeltaV - Removes time limit
-  #      department: Security
-  #      time: 54000 #15 hrs
-  #      inverted: true # stop playing intern if you're good at security!
+    #    - !type:DepartmentTimeRequirement # DeltaV - Removes time limit
+    #      department: Security
+    #      time: 54000 #15 hrs
+    #      inverted: true # stop playing intern if you're good at security!
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -6,7 +6,7 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Security
-    time: 7200 # 2 hours
+    time: 36000 # DeltaV - 10 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   startingGear: SecurityOfficerGear
   icon: "JobIconSecurityOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -4,11 +4,10 @@
   description: job-description-security
   playTimeTracker: JobSecurityOfficer
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:DepartmentTimeRequirement
-#      department: Security
-#      time: 3600 # 1 hr
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 7200 # 2 hours
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   startingGear: SecurityOfficerGear
   icon: "JobIconSecurityOfficer"
   supervisors: job-supervisors-hos
@@ -27,7 +26,7 @@
 - type: startingGear
   id: SecurityOfficerGear
   equipment:
-#    eyes: ClothingEyesGlassesSecurity # DeltaV
+    #    eyes: ClothingEyesGlassesSecurity # DeltaV
     ears: ClothingHeadsetSecurity
     pocket1: WeaponPistolMk58Nonlethal
     id: SecurityPDA # Echo Station - Separate senior roles

--- a/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
@@ -5,20 +5,19 @@
   playTimeTracker: JobSeniorOfficer
   setPreference: true # DeltaV - Readded Senior roles (removed upstream)
   requirements:
-    # Echo Station: Temporarily reduce requirements to only department hours
-#    - !type:RoleTimeRequirement
-#      role: JobWarden
-#      time: 21600 #6 hrs
-#    - !type:RoleTimeRequirement
-#      role: JobDetective
-#      time: 7200 #2 hrs
-#    - !type:RoleTimeRequirement
-#      role: JobSecurityOfficer
-#      time: 21600 #6 hrs
-#    - !type:DepartmentTimeRequirement
-#      department: Security
-#      time: 14400 # 4 hrs
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
+  - !type:RoleTimeRequirement
+    role: JobWarden
+    time: 21600 #6 hrs
+  - !type:RoleTimeRequirement
+    role: JobDetective
+    time: 7200 #2 hrs
+  - !type:RoleTimeRequirement
+    role: JobSecurityOfficer
+    time: 21600 #6 hrs
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 108000 # 30 hrs
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   startingGear: SeniorOfficerGear
   icon: "JobIconSeniorOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
@@ -16,7 +16,7 @@
     time: 21600 #6 hrs
   - !type:DepartmentTimeRequirement
     department: Security
-    time: 108000 # 30 hrs
+    time: 216000 # 60 hrs
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   startingGear: SeniorOfficerGear
   icon: "JobIconSeniorOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -6,10 +6,10 @@
   requirements:
   - !type:RoleTimeRequirement # DeltaV - JobSecurityOfficer time requirement. Make them experienced in proper officer work.
     role: JobSecurityOfficer
-    time: 14400 # 4 hrs
+    time: 36000 # DeltaV - 10 hrs
   - !type:RoleTimeRequirement # DeltaV - JobDetective time requirement. Give them an understanding of basic forensics.
     role: JobDetective
-    time: 7200 # 2 hrs
+    time: 21600 # DeltaV - 6 hours
   - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   whitelisted: true # Echo Station: Require explicit role whitelisting
   startingGear: WardenGear

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -4,17 +4,13 @@
   description: job-description-warden
   playTimeTracker: JobWarden
   requirements:
-    # Echo Station: Remove most time requirements
-#    - !type:RoleTimeRequirement # DeltaV - JobSecurityOfficer time requirement. Make them experienced in proper officer work.
-#      role: JobSecurityOfficer
-#      time: 14400 # 4 hrs
-#    - !type:RoleTimeRequirement # DeltaV - JobDetective time requirement. Give them an understanding of basic forensics.
-#      role: JobDetective
-#      time: 7200 # 2 hr
-#    - !type:DepartmentTimeRequirement
-#      department: Security
-#      time: 14400 # 4 hrs
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
+  - !type:RoleTimeRequirement # DeltaV - JobSecurityOfficer time requirement. Make them experienced in proper officer work.
+    role: JobSecurityOfficer
+    time: 14400 # 4 hrs
+  - !type:RoleTimeRequirement # DeltaV - JobDetective time requirement. Give them an understanding of basic forensics.
+    role: JobDetective
+    time: 7200 # 2 hrs
+  - !type:WhitelistRequirement # Echo Station: Require server whitelisting for all security roles
   whitelisted: true # Echo Station: Require explicit role whitelisting
   startingGear: WardenGear
   icon: "JobIconWarden"
@@ -37,7 +33,7 @@
 - type: startingGear
   id: WardenGear
   equipment:
-#    eyes: ClothingEyesGlassesSecurity # DeltaV
+    #    eyes: ClothingEyesGlassesSecurity # DeltaV
     id: WardenPDA
     ears: ClothingHeadsetSecurity
     pocket1: WeaponPistolMk58Nonlethal

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
@@ -4,9 +4,11 @@
   description: job-description-psychologist
   playTimeTracker: JobPsychologist
   requirements:
-#    - !type:OverallPlaytimeRequirement # Echo Station - to prevent griefers from taking the role.
-#      time: 14400 # 4 hours
-    - !type:WhitelistRequirement # Echo Station: Require server whitelisting
+  - !type:OverallPlaytimeRequirement
+    time: 36000 #DeltaV 10 hours
+  - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 14400 #DeltaV 4 hrs
   startingGear: PsychologistGear
   icon: "JobIconPsychologist"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
@@ -3,6 +3,9 @@
   name: job-name-reporter
   description: job-description-reporter
   playTimeTracker: JobReporter
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 7200 #DeltaV 2 hours
   startingGear: ReporterGear
   icon: "JobIconReporter"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
@@ -3,6 +3,9 @@
   name: job-name-zookeeper
   description: job-description-zookeeper
   playTimeTracker: JobZookeeper
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 7200 #DeltaV 2 hours
   startingGear: ZookeeperGear
   icon: "JobIconZookeeper"
   supervisors: job-supervisors-hop


### PR DESCRIPTION
Fixes #45 

The only nuance is it does also apply to "overall time requirements", but has a minimum of 2 hrs if that rule is present. This prevents a low multiplier from negating anti-raid time requirements introduced to some roles.