### PR TITLE
Add LinearStationEventSchedulerSystem and assigned it to the Survival…

### DIFF
--- a/Content.Server/StationEvents/Components/LinearStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/LinearStationEventSchedulerComponent.cs
@@ -1,0 +1,22 @@
+﻿namespace Content.Server.StationEvents.Components;
+
+[RegisterComponent, Access(typeof(LinearStationEventSchedulerSystem))]
+public sealed partial class LinearStationEventSchedulerComponent : Component
+{
+
+    [DataField("startTime"), ViewVariables(VVAccess.ReadWrite)]
+    public float StartTime;
+
+    [DataField("endTime"), ViewVariables(VVAccess.ReadWrite)]
+    public float EndTime;
+
+    [DataField("startMultiplier"), ViewVariables(VVAccess.ReadWrite)]
+    public float StartMultiplier;
+
+    [DataField("EndMultiplier"), ViewVariables(VVAccess.ReadWrite)]
+    public float EndMultiplier;
+
+    [DataField("timeUntilNextEvent"), ViewVariables(VVAccess.ReadWrite)]
+    public float TimeUntilNextEvent;
+
+}

--- a/Content.Server/StationEvents/Components/LinearStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/LinearStationEventSchedulerComponent.cs
@@ -1,5 +1,8 @@
 ﻿namespace Content.Server.StationEvents.Components;
 
+/// <summary>
+///     Echo Station: Introduce Linear event scheduler. See LinearStationEventSchedulerSystem for more info.
+/// </summary>
 [RegisterComponent, Access(typeof(LinearStationEventSchedulerSystem))]
 public sealed partial class LinearStationEventSchedulerComponent : Component
 {

--- a/Content.Server/StationEvents/LinearStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/LinearStationEventSchedulerSystem.cs
@@ -1,0 +1,96 @@
+﻿using Content.Server.GameTicking;
+using Content.Server.GameTicking.Components;
+using Content.Server.GameTicking.Rules;
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.StationEvents.Components;
+using Content.Server.StationEvents.Events;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+using Robust.Shared.Random;
+
+namespace Content.Server.StationEvents;
+
+/// <summary>
+///     Echo Station: Adds a linear event scheduler with high configurability to replace the standard "ramping"
+///     event scheduler. That one has many things hardcoded, including min/max event times, and a very
+///     aggressive exponential curve. The linear schedule acts as advertised.
+///
+///     Min/max event times are multiplied by the current multiplier. The multiplier is scaled linearly
+///     from StartMultiplier to EndMultiplier, starting from StartTime. If StartTime is nonzero, all time
+///     before that point will use the StartMultiplier. The same principle applies for exceeding the EndTime.
+/// </summary>
+public sealed class LinearStationEventSchedulerSystem : GameRuleSystem<LinearStationEventSchedulerComponent>
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly EventManagerSystem _event = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+
+    public float GetLinearModifier(EntityUid uid, LinearStationEventSchedulerComponent component)
+    {
+        var roundTime = (float) _gameTicker.RoundDuration().TotalSeconds;
+        if (roundTime < component.StartTime)
+            return component.StartMultiplier;
+        if (roundTime > component.EndTime)
+            return component.EndMultiplier;
+
+        // Determine how far we've progressed into the ramping.
+        var relativeRoundTime = roundTime - component.StartTime;
+        var relativeEndTime = component.EndTime - component.StartTime;
+        var ramp = relativeRoundTime / relativeEndTime; // Outputs in range: [0.0, 1.0]
+
+        // Adjust for minimum multiplier. We invert the ramp since we want to start at a high
+        // value and decrease over time, not the other way around.
+        var rampAdjusted = component.EndMultiplier + (1 - ramp) * (1 - component.EndMultiplier);
+
+        return rampAdjusted;
+    }
+
+    protected override void Started(EntityUid uid, LinearStationEventSchedulerComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        component.StartTime = _cfg.GetCVar(CCVars.EventsLinearStartTime) * 60f; // Convert minutes to seconds
+        component.EndTime = _cfg.GetCVar(CCVars.EventsLinearEndTime) * 60f; // Convert minutes to seconds
+
+        component.StartMultiplier = _cfg.GetCVar(CCVars.EventsLinearStartMultiplier);
+        component.EndMultiplier = _cfg.GetCVar(CCVars.EventsLinearEndMultiplier);
+
+        PickNextEventTime(uid, component);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (!_event.EventsEnabled)
+            return;
+
+        var query = EntityQueryEnumerator<LinearStationEventSchedulerComponent, GameRuleComponent>();
+        while (query.MoveNext(out var uid, out var scheduler, out var gameRule))
+        {
+            if (!GameTicker.IsGameRuleActive(uid, gameRule))
+                return;
+
+            if (scheduler.TimeUntilNextEvent > 0f)
+            {
+                scheduler.TimeUntilNextEvent -= frameTime;
+                return;
+            }
+
+            PickNextEventTime(uid, scheduler);
+            _event.RunRandomEvent();
+        }
+    }
+
+    private void PickNextEventTime(EntityUid uid, LinearStationEventSchedulerComponent component)
+    {
+        var mod = GetLinearModifier(uid, component);
+        // Echo Station: Make min/max configurable
+        var baselineMinTime = _cfg.GetCVar(CCVars.EventsLinearBaselineMinTime);
+        var baselineMaxTime = _cfg.GetCVar(CCVars.EventsLinearBaselineMaxTime);
+
+        // Echo Station: Use configured min/max
+        component.TimeUntilNextEvent = _random.NextFloat(baselineMinTime * mod, baselineMaxTime * mod);
+    }
+}

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -118,6 +118,44 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float>
             EventsRampingAverageChaos = CVarDef.Create("events.ramping_average_chaos", 6f, CVar.ARCHIVE | CVar.SERVERONLY);
 
+        /// <summary>
+        ///     Echo Station: Linear scaling scheduler, what time to start scaling event frequency (in minutes).
+        /// </summary>
+        public static readonly CVarDef<float>
+            EventsLinearStartTime = CVarDef.Create("events.linear_start_time", 0f, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Echo Station: Linear scaling scheduler, what time to finish scaling event frequency (in minutes).
+        /// </summary>
+        public static readonly CVarDef<float>
+            EventsLinearEndTime = CVarDef.Create("events.linear_end_time", 150f, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Echo Station: Linear scaling scheduler, the starting multiplier. Should be 1x.
+        /// </summary>
+        public static readonly CVarDef<float>
+            EventsLinearStartMultiplier = CVarDef.Create("events.linear_start_multiplier", 1.0f, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Echo Station: Linear scaling scheduler, the end multiplier. Should be a reasonable minimum value, e.g. 0.25x.
+        /// </summary>
+        public static readonly CVarDef<float>
+            EventsLinearEndMultiplier = CVarDef.Create("events.linear_end_multiplier", 0.25f, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Echo Station: Linear scaling scheduler, the baseline minimum time between events.
+        ///     Will be multiplied by the current multiplier.
+        /// </summary>
+        public static readonly CVarDef<float>
+            EventsLinearBaselineMinTime = CVarDef.Create("events.linear_baseline_min_time", 900f, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Echo Station: Linear scaling scheduler, the baseline maximum time between events.
+        ///     Will be multiplied by the current multiplier.
+        /// </summary>
+        public static readonly CVarDef<float>
+            EventsLinearBaselineMaxTime = CVarDef.Create("events.linear_baseline_max_time", 1500f, CVar.SERVERONLY);
+
         /*
          * Game
          */

--- a/Resources/ConfigPresets/EchoStation/alpha.toml
+++ b/Resources/ConfigPresets/EchoStation/alpha.toml
@@ -7,7 +7,7 @@ role_timers_multiplier = 0.2 # Increment this over time as people get more playt
 role_whitelist = true
 
 [hub]
-# Don't appear in public listings just yet.
+# Appear in public listings.
 advertise = true
 # English, America > North America > East, High RP, don't guess tags based on server name.
 tags = "lang:en-US,region:am_n_e,rp:high,no_tag_infer"

--- a/Resources/ConfigPresets/EchoStation/base.toml
+++ b/Resources/ConfigPresets/EchoStation/base.toml
@@ -5,8 +5,8 @@ desc = "A Delta-V fork focusing on high levels of roleplay. Senior roles, pionic
 lobbyenabled = true
 # The maximum number of players. Admins can join even when the cap is reached.
 soft_max_players = 30
-#
-role_timers = false
+# Role timers are enabled by default.
+role_timers = true
 # Some roles require players to be explicitly whitelisted for that individual role. Currently irrel
 role_whitelist = true
 

--- a/Resources/ConfigPresets/EchoStation/base.toml
+++ b/Resources/ConfigPresets/EchoStation/base.toml
@@ -12,7 +12,7 @@ role_whitelist = true
 
 [whitelist]
 # Whether joining requires being server whitelisted (but also read the next few settings!)
-enabled = true
+enabled = false
 
 # Echo Station: Tryout slots. This enables non-whitelisted players to join based on active (not de-admined) admins.
 [whitelist_tryout]
@@ -24,6 +24,20 @@ slots_min = 0
 slots_max = 5
 # Amount of non-whitelisted slots to add per *on-duty* admin connected.
 slots_per_admin = 2
+
+[events]
+# When to start scaling, in minutes.
+linear_start_time = 0
+# When to finish scaling, in minutes. (2.5hrs)
+linear_end_time = 150
+# Initial multiplier up to and including at StartTime.
+linear_start_multiplier = 1
+# Final multiplier, including after exceeding the EndTime.
+linear_end_multiplier = 0.25
+# Baseline minimum time between events. Multiplier by current modifier.
+linear_baseline_min_time = 900
+# Baseline maximum time between events. Multiplied by current modifier.
+linear_baseline_max_time = 1500
 
 [server]
 rules_file   = "EchoRuleset"

--- a/Resources/ConfigPresets/EchoStation/bravo.toml
+++ b/Resources/ConfigPresets/EchoStation/bravo.toml
@@ -1,5 +1,6 @@
 ﻿[game]
 hostname = "[EN] 🔶 Echo Station: Bravo | Testing server [US East]"
+desc = "Echo Station testing server with no role timers and role whitelist enabled."
 # Testing server, limit player cap:
 soft_max_players = 10
 
@@ -21,9 +22,9 @@ map_enabled = false
 enabled = true
 enable_during_round = true
 
-# Whitelist is enabled from base.toml.
-#[whitelist]
-#enabled = true
+# Whitelist is enabled.
+[whitelist]
+enabled = true
 
 [whitelist_tryout]
 enabled = false # Disable tryout slots to stop randoms from joining.

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -276,6 +276,14 @@
   components:
   - type: RampingStationEventScheduler
 
+# Echo Station: Added Linear event scheduler
+- type: entity
+  id: LinearStationEventScheduler
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: LinearStationEventScheduler
+
 # variation passes
 - type: entity
   id: BasicRoundstartVariation

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -6,7 +6,8 @@
   showInVote: true # secret # DeltaV - Me when the survival. Used for periapsis.
   description: survival-description
   rules:
-    - RampingStationEventScheduler
+    #- RampingStationEventScheduler # Echo Station: Replace Ramping with our custom Linear
+    - LinearStationEventScheduler
     - BasicRoundstartVariation
 
 - type: gamePreset
@@ -19,7 +20,8 @@
     - Traitor
     - Revolutionary
     - Zombie
-    - RampingStationEventScheduler
+    #- RampingStationEventScheduler # Echo Station: Replace Ramping with our custom Linear
+    - LinearStationEventScheduler
 
 - type: gamePreset
   id: Extended


### PR DESCRIPTION
Fixes Survival scaling being exponential:

![image](https://github.com/user-attachments/assets/ba8852b8-cd81-4183-a9c3-8f84ffb832de)

By introducing a linear scaling:

![image](https://github.com/user-attachments/assets/2a6ab92c-3d07-40f9-8ced-55cd6888abeb)

Additionally, pretty much every point on the linear graph is adjustable to your desire.

:cl:
  - add: Introduce Linear event scheduler
  - tweak: Make Survival use linear scheduler instead of exponential one
  - tweak: Massively reduce scale up speed of Survival
