### PR TITLE
Added possibility for pAI to accept encryption keys

### DIFF
--- a/Content.Server/Radio/Components/IntrinsicRadioFromKeysComponent.cs
+++ b/Content.Server/Radio/Components/IntrinsicRadioFromKeysComponent.cs
@@ -1,0 +1,19 @@
+using Content.Server.Chat.Systems;
+using Content.Shared.Chat;
+using Content.Shared.Radio;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
+
+namespace Content.Server.Radio.Components;
+
+/// <summary>
+///     Echo Station: Makes the ActiveRadioComponent and IntrinsicRadioReceiverComponent update when encryption keys change.
+///     This is necessary since you basically have to "manually" update the ActiveRadioComponent. For example, the
+///     HeadsetSystem does this manually, as does the RadioImplantSystem.
+/// </summary>
+[RegisterComponent]
+public sealed partial class IntrinsicRadioFromKeysComponent : Component
+{
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("permanentChannels", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<RadioChannelPrototype>))]
+    public HashSet<string> PermanentChannels = new();
+}

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Systems;
 using Content.Server.Power.Components;
@@ -38,6 +39,24 @@ public sealed class RadioSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<IntrinsicRadioReceiverComponent, RadioReceiveEvent>(OnIntrinsicReceive);
         SubscribeLocalEvent<IntrinsicRadioTransmitterComponent, EntitySpokeEvent>(OnIntrinsicSpeak);
+
+        SubscribeLocalEvent<IntrinsicRadioFromKeysComponent, EncryptionChannelsChangedEvent>(UpdateRadioKeys); // Echo
+    }
+
+    /// <summary>
+    ///     Echo: Added IntrinsicRadioFromKeys component to set the channels based on contained encryption keys.
+    /// </summary>
+    private void UpdateRadioKeys(EntityUid uid, IntrinsicRadioFromKeysComponent comp, EncryptionChannelsChangedEvent args)
+    {
+        if (TryComp(uid, out IntrinsicRadioTransmitterComponent? transmitter))
+        {
+            transmitter.Channels = comp.PermanentChannels.Union(args.Component.Channels).ToHashSet();
+        }
+
+        if (TryComp(uid, out ActiveRadioComponent? radio))
+        {
+            radio.Channels = comp.PermanentChannels.Union(args.Component.Channels).ToHashSet();
+        }
     }
 
     private void OnIntrinsicSpeak(EntityUid uid, IntrinsicRadioTransmitterComponent component, EntitySpokeEvent args)

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -47,14 +47,12 @@
   - type: IntrinsicRadioTransmitter
     channels: # Echo: Overridden by IntrinsicRadioFromKeys
     - Binary
-    - Common
   - type: IntrinsicRadioFromKeys # Echo: Added this to set keys based on permanent channels plus internal key container.
     permanentChannels:
     - Binary
   - type: ActiveRadio
     channels: # Echo: Overridden by IntrinsicRadioFromKeys
       - Binary
-      - Common
   - type: DoAfter
   - type: Actions
   - type: TypingIndicator

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -46,7 +46,7 @@
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
     channels: [] # Echo: Overridden by IntrinsicRadioFromKeys
-  - type: IntrinsicRadioFromKeys # Echo: Added this to set keys based on internal key container.
+  - type: IntrinsicRadioFromKeys # Echo: Added this to set keys based on permanent channels plus internal key container.
     permanentChannels:
     - Binary
   - type: ActiveRadio
@@ -73,13 +73,13 @@
           Searching: { state: pai-searching-overlay }
           On: { state: pai-on-overlay }
   - type: StationMap
-  - type: ContainerContainer # Echo: Added internal key container
+  - type: ContainerContainer # Echo: Added internal key container (in addition to permanent channels)
     containers:
-      key_slots: !type:Container # Echo: Added internal key container filling
-  - type: ContainerFill
+      key_slots: !type:Container
+  - type: ContainerFill # Echo: Default pAI starts with one removable key: Common channel
     containers:
       key_slots:
-      - EncryptionKeyCommon # This is the only key this pAI gets by default!
+      - EncryptionKeyCommon
   - type: EncryptionKeyHolder
     keySlots: 10
 
@@ -106,10 +106,10 @@
 #  - type: ActiveRadio
 #    channels:
 #    - Syndicate
-  - type: IntrinsicRadioFromKeys # Echo: Added this to set keys based on internal key container.
+  - type: IntrinsicRadioFromKeys # Echo: Added this to set keys based on permanent channels plus internal key container.
     permanentChannels:
     - Syndicate
-  - type: ContainerFill # Echo: THIS actually determines what keys this pAI has.
+  - type: ContainerFill # Echo: No additional non-permanent keys are installed.
     containers:
       key_slots: []
   - type: Appearance

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -45,12 +45,12 @@
   - type: Examiner
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
-    channels:
+    channels: [] # Echo: Overridden by IntrinsicRadioFromKeys
+  - type: IntrinsicRadioFromKeys # Echo: Added this to set keys based on internal key container.
+    permanentChannels:
     - Binary
   - type: ActiveRadio
-    channels:
-    - Binary
-    - Common
+    channels: [] # Echo: Overridden by IntrinsicRadioFromKeys
   - type: DoAfter
   - type: Actions
   - type: TypingIndicator
@@ -73,6 +73,15 @@
           Searching: { state: pai-searching-overlay }
           On: { state: pai-on-overlay }
   - type: StationMap
+  - type: ContainerContainer # Echo: Added internal key container
+    containers:
+      key_slots: !type:Container # Echo: Added internal key container filling
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCommon # This is the only key this pAI gets by default!
+  - type: EncryptionKeyHolder
+    keySlots: 10
 
 - type: entity
   parent: PersonalAI
@@ -91,12 +100,18 @@
     roleName: pai-system-role-name-syndicate
     roleDescription: pai-system-role-description-syndicate
     roleRules: ghost-role-information-familiar-rules
-  - type: IntrinsicRadioTransmitter
-    channels:
+#  - type: IntrinsicRadioTransmitter # Echo: Disable these overrides as they are useless/misleading
+#    channels:
+#    - Syndicate
+#  - type: ActiveRadio
+#    channels:
+#    - Syndicate
+  - type: IntrinsicRadioFromKeys # Echo: Added this to set keys based on internal key container.
+    permanentChannels:
     - Syndicate
-  - type: ActiveRadio
-    channels:
-    - Syndicate
+  - type: ContainerFill # Echo: THIS actually determines what keys this pAI has.
+    containers:
+      key_slots: []
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -104,7 +104,7 @@
     roleName: pai-system-role-name-syndicate
     roleDescription: pai-system-role-description-syndicate
     roleRules: ghost-role-information-familiar-rules
-  - type: IntrinsicRadioTransmitter # Echo: Disable these overrides as they are useless/misleading
+  - type: IntrinsicRadioTransmitter
     channels: # Echo: Overridden by IntrinsicRadioFromKeys
     - Syndicate
   - type: ActiveRadio

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -25,7 +25,7 @@
     - state: pai-base
     - state: pai-off-overlay
       shader: unshaded
-      map: ["screen"]
+      map: [ "screen" ]
   - type: Input
     context: "human"
   - type: PAI
@@ -45,12 +45,16 @@
   - type: Examiner
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
-    channels: [] # Echo: Overridden by IntrinsicRadioFromKeys
+    channels: # Echo: Overridden by IntrinsicRadioFromKeys
+    - Binary
+    - Common
   - type: IntrinsicRadioFromKeys # Echo: Added this to set keys based on permanent channels plus internal key container.
     permanentChannels:
     - Binary
   - type: ActiveRadio
-    channels: [] # Echo: Overridden by IntrinsicRadioFromKeys
+    channels: # Echo: Overridden by IntrinsicRadioFromKeys
+      - Binary
+      - Common
   - type: DoAfter
   - type: Actions
   - type: TypingIndicator
@@ -95,23 +99,23 @@
     - state: pai-base
     - state: syndicate-pai-off-overlay
       shader: unshaded
-      map: ["screen"]
+      map: [ "screen" ]
   - type: ToggleableGhostRole
     roleName: pai-system-role-name-syndicate
     roleDescription: pai-system-role-description-syndicate
     roleRules: ghost-role-information-familiar-rules
-#  - type: IntrinsicRadioTransmitter # Echo: Disable these overrides as they are useless/misleading
-#    channels:
-#    - Syndicate
-#  - type: ActiveRadio
-#    channels:
-#    - Syndicate
+  - type: IntrinsicRadioTransmitter # Echo: Disable these overrides as they are useless/misleading
+    channels: # Echo: Overridden by IntrinsicRadioFromKeys
+    - Syndicate
+  - type: ActiveRadio
+    channels: # Echo: Overridden by IntrinsicRadioFromKeys
+    - Syndicate
   - type: IntrinsicRadioFromKeys # Echo: Added this to set keys based on permanent channels plus internal key container.
     permanentChannels:
     - Syndicate
   - type: ContainerFill # Echo: No additional non-permanent keys are installed.
     containers:
-      key_slots: []
+      key_slots: [ ]
   - type: Appearance
   - type: GenericVisualizer
     visuals:
@@ -133,7 +137,7 @@
     - state: potato-base
     - state: potato-off-overlay
       shader: unshaded
-      map: ["screen"]
+      map: [ "screen" ]
   - type: ToggleableGhostRole
     roleName: pai-system-role-name-potato
     roleDescription: pai-system-role-description-potato
@@ -167,9 +171,9 @@
   name: Open Map
   description: Open your map interface and guide your owner.
   components:
-    - type: InstantAction
-      checkCanInteract: false
-      checkConsciousness: false
-      icon: { sprite: Interface/Actions/pai-map.rsi, state: icon }
-      event: !type:OpenUiActionEvent
-        key: enum.StationMapUiKey.Key
+  - type: InstantAction
+    checkCanInteract: false
+    checkConsciousness: false
+    icon: { sprite: Interface/Actions/pai-map.rsi, state: icon }
+    event: !type:OpenUiActionEvent
+      key: enum.StationMapUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -171,9 +171,9 @@
   name: Open Map
   description: Open your map interface and guide your owner.
   components:
-  - type: InstantAction
-    checkCanInteract: false
-    checkConsciousness: false
-    icon: { sprite: Interface/Actions/pai-map.rsi, state: icon }
-    event: !type:OpenUiActionEvent
-      key: enum.StationMapUiKey.Key
+    - type: InstantAction
+      checkCanInteract: false
+      checkConsciousness: false
+      icon: { sprite: Interface/Actions/pai-map.rsi, state: icon }
+      event: !type:OpenUiActionEvent
+        key: enum.StationMapUiKey.Key


### PR DESCRIPTION
Added possibility for pAI to accept encryption keys. The default and potato pAI have the Binary channel permanently, and a removable Common key, and the Syndicate pAI has the Syndicate channel permanently with no additional default keys.

:cl:
- add: All pAI can now accept encryption keys
- tweak: Regular pAI's Common channel access is now encryption key dependent, though it does start with a Common key. (Binary key is permanent.)
