### PR TITLE
Add ability to pAIs to change their own name

### DIFF
--- a/Content.Shared/PAI/PAIComponent.cs
+++ b/Content.Shared/PAI/PAIComponent.cs
@@ -1,6 +1,6 @@
+using Content.Shared.Actions;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.PAI;
 
@@ -33,6 +33,12 @@ public sealed partial class PAIComponent : Component
     [DataField]
     public ProtoId<EntityPrototype> MapActionId = "ActionPAIOpenMap";
 
+    [DataField(serverOnly: true)] // server only, as it uses a server-BUI event !type
+    public EntityUid? RenameAction;
+
+    [DataField]
+    public ProtoId<EntityPrototype> RenameActionID = "ActionPAIRename";
+
     [DataField, AutoNetworkedField]
     public EntityUid? MapAction;
 
@@ -54,3 +60,11 @@ public sealed partial class PAIComponent : Component
     [DataField]
     public string ScramblePopup = "pai-system-scramble-popup";
 }
+
+/// <summary>
+/// Echo: Fired when a pAI player presses the Rename button.
+/// </summary>
+public sealed partial class PAIRenameActionEvent : InstantActionEvent
+{
+}
+

--- a/Content.Shared/PAI/SharedPAISystem.cs
+++ b/Content.Shared/PAI/SharedPAISystem.cs
@@ -27,12 +27,14 @@ namespace Content.Shared.PAI
         {
             _actionsSystem.AddAction(uid, ref component.MidiAction, component.MidiActionId);
             _actionsSystem.AddAction(uid, ref component.MapAction, component.MapActionId);
+            _actionsSystem.AddAction(uid, ref component.RenameAction, component.RenameActionID); // Echo: Added Rename action
         }
 
         private void OnShutdown(EntityUid uid, PAIComponent component, ComponentShutdown args)
         {
             _actionsSystem.RemoveAction(uid, component.MidiAction);
             _actionsSystem.RemoveAction(uid, component.MapAction);
+            _actionsSystem.RemoveAction(uid, component.RenameAction); // Echo: Added Rename action
         }
     }
 }

--- a/Resources/Prototypes/_Echo/Actions/pai-actions.yml
+++ b/Resources/Prototypes/_Echo/Actions/pai-actions.yml
@@ -1,0 +1,10 @@
+﻿
+- type: entity
+  id: ActionPAIRename
+  name: Rename yourself
+  description: Rename yourself. Usable once every 5 minutes.
+  components:
+  - type: InstantAction
+    icon: Interface/AdminActions/rename.png
+    checkCanInteract: false
+    event: !type:PAIRenameActionEvent {}


### PR DESCRIPTION
- Once every five minutes
- It always prepends a "pAI" prefix to prevent impersonation, e.g. "Peter" becomes "pAI Peter"


## OLD video without prefix
https://github.com/user-attachments/assets/3ef6366e-9c82-49b7-b849-aaee74f8f73f

## Result WITH prefix

If you enter e.g. "Agent Whiskey":
![Content Client_R7tprSmJGZ](https://github.com/user-attachments/assets/ca953139-679a-4abd-a5af-b56039362f8d)



:cl:
- add: pAIs can now set their own names, with a "pAI" prefix to prevent impersonation
