### PR TITLE
Buff portable particle decelerator to be useful

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
@@ -77,4 +77,4 @@
   - type: TimedDespawn
     lifetime: 0.6
   - type: SinguloFood
-    energy: -10
+    energy: -150


### PR DESCRIPTION
Portable particle decelerator is currently useless, since it only removes 10 energy from a singulo per shot.

If a singulo eats one or two tiles it's already offset that.

This buffs the damage to 150 energy per shot.


:cl:
- fix: Portable particle decelerator now does substantial damage against singularities
