### PR TITLE
Fix Echo-specific jobs not showing up on AAC tablet correctly

### DIFF
--- a/Resources/Prototypes/DeltaV/QuickPhrases/jobs.yml
+++ b/Resources/Prototypes/DeltaV/QuickPhrases/jobs.yml
@@ -151,12 +151,12 @@
 #  text: job-name-chief-justice
 
 - type: quickPhrase
-  parent: BaseCivilianPhrase # Echo: No Justice department, Lawyer is Civ
+  parent: BaseCivilianJobPhrase # Echo: No Justice department, Lawyer is Civ
   id: LawyerPhrase
   text: job-name-lawyer
 
 - type: quickPhrase
-  parent: BaseSecurityPhrase # Echo: No Justice department, Prosecutor is Sec
+  parent: BaseSecurityJobPhrase # Echo: No Justice department, Prosecutor is Sec
   id: ProsecutorPhrase
   text: job-name-prosecutor
 


### PR DESCRIPTION
Fixes #92 

:cl:
- fix: Lawyer and Prosecutor now show up on the AAC tablet correctly