### PR TITLE
Bump time requirement multiplier from 0.2x to 0.3x

### DIFF
--- a/Resources/ConfigPresets/EchoStation/alpha.toml
+++ b/Resources/ConfigPresets/EchoStation/alpha.toml
@@ -3,7 +3,7 @@ hostname = "[EN] 🔷 Echo Station: Alpha | Quality RP | Whitelist with Tryout s
 
 # Role timers are now ON, but all time requirements are multiplied by the multiplier below.
 role_timers = true
-role_timers_multiplier = 0.2 # Increment this over time as people get more playtime in
+role_timers_multiplier = 0.3 # Increment this over time as people get more playtime in
 role_whitelist = true
 
 [hub]


### PR DESCRIPTION
It's time.

:cl:
- tweak: Bump job time requirement multiplier from 0.2x to 0.3x
