### PR TITLE
Multiple menial string changes for listed issues

### DIFF
--- a/Resources/Locale/en-US/_Echo/job-names.ftl
+++ b/Resources/Locale/en-US/_Echo/job-names.ftl
@@ -1,7 +1,7 @@
 ﻿# Job names
-job-name-blueshield = Blueshield
+job-name-blueshield = Blueshield Officer
 job-name-executive-officer = Executive Officer
 
 # Job timers
-JobBlueshield = Blueshield
+JobBlueshield = Blueshield Officer
 JobExecutiveOfficer = Executive Officer

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1054,7 +1054,6 @@
       - MedkitBrute
       - MedkitAdvanced
       - MedkitRadiation
-      - MedkitCombat
       - Scalpel
       - Retractor
       - Cautery

--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -90,7 +90,7 @@
   - type: Rotatable
   - type: Repairable
     doAfterDelay: 5
-    fuelCost: 25
+    fuelCost: 10
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -45,8 +45,8 @@
     layerMap: "airAlarmBase"
     alarmStates:
       Normal: alarm0
-      Warning: alarm2
-      Danger: alarm1
+      Warning: alarm1
+      Danger: alarm2
     setOnDepowered:
       airAlarmBase: alarmp
   - type: Tag

--- a/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
@@ -9,7 +9,7 @@
   - type: Icon
     sprite: Structures/Windows/reinforced_window.rsi
   - type: Repairable
-    fuelCost: 10
+    fuelCost: 6
     doAfterDelay: 2
   - type: Damageable
     damageContainer: StructuralInorganic

--- a/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
@@ -9,7 +9,7 @@
   - type: Icon
     sprite: Structures/Windows/shuttle_window.rsi
   - type: Repairable
-    fuelCost: 15
+    fuelCost: 10
     doAfterDelay: 3
   - type: Damageable
     damageContainer: StructuralInorganic


### PR DESCRIPTION

## About the PR
Reduced welding prices for the recycler, reinforced windows and shuttle windows.
Medical techfab no longer can print the combat medkit.
Swapped the air alarm danger and warning sprites.
Blueshield Officer now displays instead of Blueshield.

## Why / Balance
Following issues:
https://github.com/echo-station/echo-station/issues/87
https://github.com/echo-station/echo-station/issues/85
https://github.com/echo-station/echo-station/issues/68
https://github.com/echo-station/echo-station/issues/18

## Technical details
Simply removed combat medkit from the lines of possible items in lathes.yml
Changed fuel costs for welding in shuttle.yml (15 --> 10), reinforced.yml (10 --> 6), recycler.yml (25 --> 10)
In air_alarm.yml, warning and danger states were misplaced. Simply switched warning to alarm1 and danger to alarm2.
In job-names.ftl, replaced Blueshield with Blueshield Officer.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

